### PR TITLE
Feature/sections label and order

### DIFF
--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -104,7 +104,7 @@ const getD2Section = (d2, section) => {
 
 const getOutputSection = (dataElements, opts) => {
     const {d2, config, coreCompetency} = opts;
-    const sectionName = coreCompetency.name;
+    const sectionName = coreCompetency.name + " Outputs";
     const filteredDataElements =
         filterDataElements(dataElements, [coreCompetency.id, config.dataElementGroupOutputId])
     return getSection(sectionName, filteredDataElements, [], {}, opts);
@@ -112,7 +112,7 @@ const getOutputSection = (dataElements, opts) => {
 
 const getOutcomeSection = (dataElements, opts) => {
     const {d2, config, indicatorsByGroupName, coreCompetency} = opts;
-    const sectionName = coreCompetency.name + " (B)";
+    const sectionName = coreCompetency.name + " Outcomes";
     const outcomeDataElements =
         filterDataElements(dataElements, [coreCompetency.id, config.dataElementGroupOutcomeId]);
     const indicators = indicatorsByGroupName[coreCompetency.name];

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -129,7 +129,7 @@ const getOutcomeSection = (dataElements, opts) => {
 
 const getSection = (sectionName, dataElements, indicators, filtersToIndicators, opts) => {
     const {d2, config, relations, coreCompetency} = opts;
-    const dataElementsData = dataElements.map(de => {
+    const getDataElementInfo = (de) => {
         const indicators = _([
             filtersToIndicators["id." + de.id],
             filtersToIndicators["code." + de.code],
@@ -147,13 +147,18 @@ const getSection = (sectionName, dataElements, indicators, filtersToIndicators, 
             origin: degSetOrigin ? degSetOrigin.name : "None",
             disaggregation: de.categoryCombo.name == "default" ? "None" : de.categoryCombo.name,
         };
-    });
+    };
+    const indexedDataElementsInfo = _(dataElements)
+        .map(getDataElementInfo)
+        .sortBy(de => [!de.selected, de.name])
+        .keyBy("id")
+        .value();
 
     return {
         name: sectionName,
         showRowTotals: false,
         showColumnTotals: false,
-        dataElements: _.keyBy(dataElementsData, "id"),
+        dataElements: indexedDataElementsInfo,
     };
 };
 


### PR DESCRIPTION
Closes #63, #64 

DataElements sorted by (selected DESC, name ASC).

Nitpicking: The dataElements appear with the desired ordering on the first render. If the user clicks on a header to sort by that column, there is no way to return to the default sorting order other than changing of section (for that, we should add a mechanism to disable sorting on a column). Control+click, shift+click, something like that.  

![dhis2-sections](https://user-images.githubusercontent.com/24643/27683376-04dc70b6-5cc6-11e7-98d9-f584af8f5c24.png)
