### PR TITLE
Reduce RichDropdown width and make icon clickable

### DIFF
--- a/src/forms/FormHelpers.js
+++ b/src/forms/FormHelpers.js
@@ -52,7 +52,7 @@ function getRichSelectField({name, label, options, filterOptions,
             filterOptions: filterOptions,
             isRequired: isRequired,
             labelText: getLabel(label, isRequired),
-            style: {width: "100%"},
+            style: {width: "30%"},
             controls: controls,
         },
     };

--- a/src/forms/RichDropdown.component.js
+++ b/src/forms/RichDropdown.component.js
@@ -154,7 +154,8 @@ class RichDropdown extends React.Component {
                     inputStyle={{ cursor: 'pointer' }}
                 />
                 <div
-                    style={{ position: 'absolute', top: 38, right: 4, color: 'rgba(0,0,0,0.25)' }}
+                    onClick={this.openDialog}
+                    style={{ cursor: 'pointer', position: 'relative', color: 'rgba(0,0,0,0.25)' }}
                     className='material-icons'
                 >open_in_new</div>
             </div>


### PR DESCRIPTION
Closes #62 

- Width set to 30%
- The icon was not clickable, now it is.

![dhis2-wizard-initial](https://user-images.githubusercontent.com/24643/27685365-26d9d35e-5cce-11e7-889a-5fb1a96372ea.png)
