### PR TITLE
Implement wizard edit

### DIFF
--- a/src/DataSets/FormSteps.component.js
+++ b/src/DataSets/FormSteps.component.js
@@ -11,6 +11,7 @@ import Disaggregation from './Forms/Disaggregation.component';
 import Sharing from './Forms/Sharing.component';
 import GreyFields from './Forms/GreyFields.component';
 import Save from './Forms/Save.component';
+import snackActions from '../Snackbar/snack.actions';
 
 import DataSetStore from '../models/DataSetStore';
 import Settings from '../models/Settings';
@@ -30,14 +31,19 @@ const DataSetFormSteps = React.createClass({
     },
 
     componentDidMount() {
-        const settings = new Settings(this.context.d2);
+        const {d2} = this.context;
+        const settings = new Settings(d2);
+        const {id: datasetId} = this.props.params;
+
         settings.get()
             .then(config => {
-                this.setState({
-                    store: new DataSetStore(this.context.d2, config),
-                });
+                return DataSetStore.get(d2, config, datasetId)
+                    .then(store => this.setState({store}))
+                    .catch(err => snackActions.show({route: "/", message: `Cannot edit dataset: ${err}`}));
             })
-            .catch(err => alert('Error: settings not found'));
+            .catch(err => {
+                snackActions.show({route: "/", message: `Error: settings not found: ${err}`});
+            });
     },
 
     _onFieldsChange(stepId, fieldPath, newValue, update = true) {

--- a/src/DataSets/Forms/Sections.component.js
+++ b/src/DataSets/Forms/Sections.component.js
@@ -244,12 +244,12 @@ const Sections = React.createClass({
     componentDidMount() {
         const {d2} = this.context;
         const {config} = this.props;
-        const {coreCompetencies, stateSections} = this.props.store.associations;
+        const {dataset, associations} = this.props.store;
+        const {coreCompetencies, sections} = associations;
 
-        Section.getSectionsFromCoreCompetencies(d2, config, coreCompetencies).then(sectionsArray => {
-            const loadedSections = _.keyBy(sectionsArray, "name");
+        Section.getSectionsFromCoreCompetencies(d2, config, sections, coreCompetencies).then(sectionsArray => {
+            const sections = _.keyBy(sectionsArray, "name");
             const sectionNames = sectionsArray.map(section => section.name);
-            const sections = _.merge(loadedSections, _.pick(stateSections, _.keys(loadedSections)));
 
             this.setState({
                 isLoading: false,
@@ -261,7 +261,8 @@ const Sections = React.createClass({
     },
 
     _updateModelSections() {
-        const errors = this.props.store.updateModelSections(this.state.sections);
+        const {sections} = this.props.store.associations;
+        const errors = this.props.store.updateModelSections(this.state.sections, sections);
         this.setState({errors: errors});
         return _(errors).isEmpty();
     },

--- a/src/DataSets/context.actions.js
+++ b/src/DataSets/context.actions.js
@@ -32,8 +32,7 @@ contextActions.details
 contextActions.edit
     .subscribe(({ data: model }) => getD2()
         .then(d2 => {
-            console.log(model)
-            alert("TODO: dataset edit");
+            goToRoute('/datasets/edit/' + model.id);
         })
     );
 

--- a/src/MultipleDataTable/MultipleDataTableContextMenu.component.js
+++ b/src/MultipleDataTable/MultipleDataTableContextMenu.component.js
@@ -32,22 +32,24 @@ const MultipleDataTableContextMenu = React.createClass({
         const cmStyle = {
             position: 'fixed',
         };
+        const {actions, target, activeItems, icons, showContextMenu, ...popoverProps} = this.props;
+
         return (
             <Popover
-                {...this.props}
-                open={this.props.showContextMenu}
-                anchorEl={this.props.target}
+                {...popoverProps}
+                open={showContextMenu}
+                anchorEl={target}
                 anchorOrigin={{horizontal: 'middle', vertical: 'center'}}
                 animated={false}
                 style={cmStyle}
                 animation={Paper}
             >
-                <Menu className="data-table__context-menu" openDirection="bottom-right" desktop>
+                <Menu className="data-table__context-menu" desktop>
                     {actionList.map((action) => {
-                        const iconName = this.props.icons[action] ? this.props.icons[action] : action;
+                        const iconName = icons[action] ? icons[action] : action;
 
                         return (<MenuItem key={action}
-                                          data-object-id={this.props.activeItems}
+                                          data-object-id={activeItems}
                                           className={'data-table__context-menu__item'}
                                           onClick={this.handleClick.bind(this, action)}
                                           primaryText={this.getTranslation(action)}

--- a/src/Snackbar/snack.actions.js
+++ b/src/Snackbar/snack.actions.js
@@ -1,17 +1,22 @@
 import Action from 'd2-ui/lib/action/Action';
 import snackStore from './snack.store';
 import { config, getInstance as getD2 } from 'd2/lib/d2';
+import { goToRoute } from '../router';
 
-const snackActions = Action.createActionsFromNames(['show', 'hide']);
+const snackActions = Action.createActionsFromNames(['show', 'showAndRedirect', 'hide']);
 
 snackActions.show.subscribe(actionConfig => {
-    const { message, action, autoHideDuration, onActionTouchTap, translate } = actionConfig.data;
+    const { message, action, autoHideDuration, onActionTouchTap, translate, route } = actionConfig.data;
+
+    if (route) {
+        goToRoute(route);
+    }
 
     getD2()
         .then((d2) => {
             snackStore.setState({
                 message: translate ? d2.i18n.getTranslation(message) : message,
-                action,
+                action: action || "ok",
                 autoHideDuration,
                 onActionTouchTap: onActionTouchTap || (() => {
                     snackActions.hide();

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -53,10 +53,6 @@ class Factory {
                 .then(associations => new DataSetStore(this.d2, this.config, dataset, associations)));
     }
 
-    getTranslation(...args) {
-        return this.d2.i18n.getTranslation(...args);
-    }
-
     getInitialModel() {
         return this.d2.models.dataSet.create({
             name: undefined,
@@ -129,8 +125,11 @@ export default class DataSetStore {
         this.config = config;
         this.dataset = dataset;
         this.associations = associations;
-        this.getTranslation = d2.i18n.getTranslation;
         window.store = this;
+    }
+
+    getTranslation(...args) {
+        return this.d2.i18n.getTranslation(...args);
     }
 
     static get(d2, config, datasetId = null) {

--- a/src/router.js
+++ b/src/router.js
@@ -4,13 +4,15 @@ import log from 'loglevel';
 import App from './App/App.component';
 import DataSets from './DataSets/DataSets.component';
 import DataSetFormSteps from './DataSets/FormSteps.component';
+import snackActions from './Snackbar/snack.actions';
 
 const routes = (
     <Router history={hashHistory}>
-        <Route path="/" component={App}>      
+        <Route path="/" component={App}>
             <IndexRedirect to="datasets" />
             <Route path="datasets" component={DataSets}/>
             <Route path="datasets/add" component={DataSetFormSteps}/>
+            <Route path="datasets/edit/:id" component={DataSetFormSteps} />
         </Route>
     </Router>
 );


### PR DESCRIPTION
Closes #114 

As we expected, the non-1:1 relationships with dhis2 entities (sections split, disaggregations being added instead of being set, etc) introduces some friction on the edit functionality. Surely you'll have some doubts when testing, we can check it together tomorrow.