### PR TITLE
Feature/add indicators to outcome sections

### DIFF
--- a/resources/customjscss/nrc.css
+++ b/resources/customjscss/nrc.css
@@ -99,6 +99,16 @@ border-color: #fff;
 
 }
 
+.indicatorArea {
+    margin-top: -50px;
+    margin-bottom: 5px;
+    border-top: none;
+}
+
+.indicatorArea td {
+    width: 100% !important;
+    text-align: left !important;
+}
 
 .entryfield,
 .indicator
@@ -298,6 +308,7 @@ background-color: grey;
     width: 70px;
     height: 18px;
     padding: 2px;
+    background-color: #CCC;
 }
 
 #contentDiv tr:hover {

--- a/src/DataSets/FormSteps.component.js
+++ b/src/DataSets/FormSteps.component.js
@@ -23,7 +23,7 @@ const DataSetFormSteps = React.createClass({
     getInitialState() {
         return {
             store: null,
-            active: 0,
+            active: 4-1,
             doneUntil: 0,
             validating: false,
             saving: false,

--- a/src/DataSets/FormSteps.component.js
+++ b/src/DataSets/FormSteps.component.js
@@ -23,7 +23,7 @@ const DataSetFormSteps = React.createClass({
     getInitialState() {
         return {
             store: null,
-            active: 4-1,
+            active: 0,
             doneUntil: 0,
             validating: false,
             saving: false,

--- a/src/forms/DataSetElementCategoryComboSelectionDialog.component.js
+++ b/src/forms/DataSetElementCategoryComboSelectionDialog.component.js
@@ -140,7 +140,6 @@ function DataSetElementList({ dataSetElements, categoryCombos, onCategoryComboSe
     const getCategoryCombosForSelect = createGetCategoryCombosForSelect(d2, categoryCombos);
 
     const dataSetElementsRows = dataSetElements
-        .sort((left, right) => ((left.dataElement && left.dataElement.displayName || '').localeCompare(right.dataElement && right.dataElement.displayName)))
         .map(({ categoryCombo = {}, dataElement = {}, id }) => {
             const selectedCatCombo = (categoryCombo.source || categoryCombo);
             const categoryCombosForSelect = getCategoryCombosForSelect(dataElement.categoryCombo, selectedCatCombo);

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -39,7 +39,7 @@ export const getSections = (d2, config, dataset, d2Sections, initialCoreCompeten
                 indicatorsByGroupName, dataElementsByCCId,
             };
             return [getOutputSection(opts), getOutcomeSection(opts)];
-		})).then(sections => updateSectionsFromD2Sections(dataset, sections, d2Sections, initialCoreCompetencies));
+		})).then(sections => updateSectionsFromD2Sections(sections, d2Sections, initialCoreCompetencies));
 	});
 };
 
@@ -102,11 +102,11 @@ const getSectionName = (d2Section) => {
     return d2Section.name.split("@")[0];
 };
 
-const updateSectionsFromD2Sections = (dataset, sections, d2Sections, initialCoreCompetencies) => {
+const updateSectionsFromD2Sections = (sections, d2Sections, initialCoreCompetencies) => {
     const d2SectionsByName = _(d2Sections).groupBy(getSectionName).value();
     const getItemIds = (d2Sections) =>
          _(d2Sections)
-            .flatMap(d2s => [d2s.dataElements, dataset.indicators])
+            .flatMap(d2s => [d2s.dataElements, d2s.indicators])
             .flatMap(collection => collectionToArray(collection).map(obj => obj.id))
             .value();
     const updateSection = section => {
@@ -144,8 +144,7 @@ const getD2Sections = (d2, section) => {
             showRowTotals: section.showRowTotals,
             showColumnTotals: section.showColumnTotals,
             dataElements: dataElements.map(de => ({id: de.id})),
-            // No indicators for section, just in the data set (they are not rendered in data-entry)
-            indicators: [],
+            indicators: indicators.map(ind => ({id: ind.id})),
             greyedFields: [],
         });
     };


### PR DESCRIPTION
Closes #172 

- Indicators added to section (in N/D/C order)
- Order of data elements in disaggregation was alphabetical, now original order is preserved.
- Check #172 for the double rendering of the indicator.

![screenshot from 2017-11-07 09-18-44](https://user-images.githubusercontent.com/24643/32483704-6dc83202-c39d-11e7-8229-c4ba572720b7.png)
