### PR TITLE
Fix sharing/orgUnits actions

### DIFF
--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -88,23 +88,21 @@ const DataSets = React.createClass({
         const d2 = this.context.d2;
         this.getDataSets();
         
-        this.registerDisposable(detailsStore.subscribe(detailsObject => {
-            this.setState({ detailsObject });
-        }));
+        this.registerDisposable(detailsStore.subscribe(detailsObject => this.setState({detailsObject})));
+        this.registerDisposable(deleteStore.subscribe(deleteObjects => this.getDataSets()));
+        this.registerDisposable(this.subscribeToModelStore(sharingStore, "sharing"));
+        this.registerDisposable(this.subscribeToModelStore(orgUnitsStore, "orgUnits"));
+    },
 
-        this.registerDisposable(deleteStore.subscribe(deleteObjects => {
-            this.getDataSets();
-        }));
-
-        this.registerDisposable(orgUnitsStore.subscribe(datasets => {
-            const d2Datasets = datasets.map(dataset => d2.models.dataSets.create(dataset));
-            this.setState({orgUnits: {models: d2Datasets}});
-        }));
-
-        this.registerDisposable(sharingStore.subscribe(datasets => {
-            const d2Datasets = datasets.map(dataset => d2.models.dataSets.create(dataset));
-            this.setState({sharing: {models: d2Datasets}});
-        }));
+    subscribeToModelStore(store, modelName) {
+        return store.subscribe(datasets => {
+            if (datasets) {
+                const d2Datasets = datasets.map(dataset => d2.models.dataSets.create(dataset));
+                this.setState({[modelName]: {models: d2Datasets}});
+            } else {
+                this.setState({[modelName]: null});
+            }
+        });
     },
 
     getDataSets() {
@@ -255,7 +253,7 @@ const DataSets = React.createClass({
                 {this.state.orgUnits ? <OrgUnitsDialog
                      objects={this.state.orgUnits.models}
                      open={true}
-                     onRequestClose={() => this.setState({orgUnits: null})}
+                     onRequestClose={listActions.hideOrgUnitsBox}
                      contentStyle={{width: '1150px', maxWidth: 'none'}}
                      bodyStyle={{minHeight: '440px', maxHeight: '600px'}}
                  /> : null }
@@ -263,7 +261,7 @@ const DataSets = React.createClass({
                 {this.state.sharing ? <SharingDialog
                     objectsToShare={this.state.sharing.models}
                     open={true}
-                    onRequestClose={() => this.setState({sharing: null})}
+                    onRequestClose={listActions.hideSharingBox}
                     bodyStyle={{minHeight: '400px'}}
                 /> : null }
 

--- a/src/DataSets/list.actions.js
+++ b/src/DataSets/list.actions.js
@@ -1,9 +1,17 @@
 import Action from 'd2-ui/lib/action/Action';
 import detailsStore from './details.store';
+import sharingStore from './sharing.store';
+import orgUnitsStore from './orgUnits.store';
 import { getInstance } from 'd2/lib/d2';
 import { Observable } from 'rx';
 
-const listActions = Action.createActionsFromNames(['getNextPage', 'getPreviousPage', 'hideDetailsBox']);
+const listActions = Action.createActionsFromNames([
+  'getNextPage',
+  'getPreviousPage',
+  'hideDetailsBox',
+  'hideSharingBox',
+  'hideOrgUnitsBox',
+]);
 
 // TODO: For simple action mapping like this we should be able to do something less boiler plate like
 listActions.getNextPage.subscribe(() => {
@@ -16,6 +24,14 @@ listActions.getPreviousPage.subscribe(() => {
 
 listActions.hideDetailsBox.subscribe(() => {
     detailsStore.setState(null);
+});
+
+listActions.hideSharingBox.subscribe(() => {
+    sharingStore.setState(null);
+});
+
+listActions.hideOrgUnitsBox.subscribe(() => {
+    orgUnitsStore.setState(null);
 });
 
 export default listActions;


### PR DESCRIPTION
When opening a share/orgUnits dialog, then closing, then editing a dataset, then returning to the dataset list, the dialogs would pop up again.