### PR TITLE
Feature/autoselect project attribute 310

### DIFF
--- a/resources/customjscss/data-entry-contentscript.js
+++ b/resources/customjscss/data-entry-contentscript.js
@@ -8,8 +8,29 @@
         fixActionsBox();
     };
 
+    var selectProjectFromDataset = function(ev) {
+        var dataSetName = $("#selectedDataSetId option:selected").text();
+
+        var projectSelect = $(".selectionLabel")
+            .filter(function() { return $(this).text() === "Project" })
+            .siblings("select");
+        var optionToSelect = projectSelect
+            .find("option")
+            .filter(function() { return dataSetName.indexOf($(this).text()) >= 0; });
+        if (optionToSelect.get(0)) {
+            optionToSelect.prop("selected", true);
+        } else {
+            projectSelect.find("option:first").prop("selected", true);
+        }
+    };
+
+    var autoselectProject = function() {
+        $("#selectedDataSetId, #selectedPeriodId").change(selectProjectFromDataset);
+    };
+
     var init = function() {
         $(document).on("dhis2.de.event.formLoaded", applyChangesToForm);
+        autoselectProject();
     };
 
     $(init);

--- a/src/models/CustomForm.js
+++ b/src/models/CustomForm.js
@@ -2,6 +2,16 @@ import velocity from 'velocityjs';
 import htmlencode from 'htmlencode';
 import _ from '../utils/lodash-mixins';
 
+import customFormTemplate from '!!raw-loader!./custom-form-resources/sectionForm.vm';
+import customFormJs from '!!raw-loader!./custom-form-resources/script.js';
+import customFormCss from '!!raw-loader!./custom-form-resources/style.css';
+
+const data = {
+  template: customFormTemplate,
+  css: customFormCss,
+  js: customFormJs,
+};
+
 const a = (obj) => obj.toArray ? obj.toArray() : obj;
 const _a = (...args) => _(a(...args));
 
@@ -124,7 +134,7 @@ const getContext = (d2, dataset, richSections, allCategoryCombos) => {
       htmlEncode: htmlencode.htmlEncode,
     },
     auth: {
-      // Used in automatic form, cannot be calculated for a static custom form, leave as true
+      // Used in automatic form, cannot be calculated for a static custom form, leave it as true
       hasAccess: (app, key) => true,
     },
     dataSet: {
@@ -139,17 +149,14 @@ const getContext = (d2, dataset, richSections, allCategoryCombos) => {
   };
 };
 
-const get = (d2, dataset, sections, categoryCombos, data) => {
+const get = (d2, dataset, project, sections, categoryCombos) => {
   const context = getContext(d2, dataset, sections, categoryCombos);
   const config = {env: "development", escape: false};
   const htmlForm = velocity.render(data.template, context, {}, config);
+
   return `
-    <style>
-      ${data.css}
-    </style>
-    <script>
-      ${data.js}
-    </script>
+    <style>${data.css}</style>
+    <script>${data.js}</script>
     ${htmlForm}
   `;
 };

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -22,9 +22,6 @@ import {getCategoryCombos,
        } from '../utils/Dhis2Helpers';
 import * as Section from './Section';
 import getCustomForm from './CustomForm';
-import customFormTemplate from '!!raw-loader!./custom-form-resources/sectionForm.vm';
-import customFormJs from '!!raw-loader!./custom-form-resources/script.js';
-import customFormCss from '!!raw-loader!./custom-form-resources/style.css';
 
 // From maintenance-app/src/EditModel/objectActions.js
 const extractErrorMessagesFromResponse = compose(
@@ -230,13 +227,12 @@ export default class DataSetStore {
     }
 
     _saveCustomForm(saving) {
-        const {richSections, dataset} = saving;
+        const {richSections, dataset, project} = saving;
         const categoryCombos$ = getCategoryCombos(this.d2);
-        const data = {template: customFormTemplate, css: customFormCss, js: customFormJs};
         const api = this.d2.Api.getApi();
 
         return categoryCombos$.then(categoryCombos => {
-            const htmlCode = getCustomForm(this.d2, dataset, richSections, categoryCombos, data);
+            const htmlCode = getCustomForm(this.d2, dataset, project, richSections, categoryCombos);
             const payload = {style: "NORMAL", htmlCode};
             return api.post(['dataSets', dataset.id, 'form'].join('/'), payload).then(() => saving);
         });


### PR DESCRIPTION
Closes #310 

The category.id/categoryOption.id relationships could be easily included in the custom form, but the JS code in a custom form is not executed until the form is rendered (and all selectors have value,) So the only way is to perform the same logic we apply in dataset-configuration: `if datasetName.includes(project.name) then select(project)`.