### PR TITLE
Feature/logs paging

### DIFF
--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -327,13 +327,6 @@ const DataSets = React.createClass({
             />,
         ];
 
-        const helpActions = [
-            <FlatButton
-                label={this.tr("close")}
-                onClick={this._closeHelp}
-            />,
-        ];
-
         const renderLogs = () => {
             const logs = this.state.logs;  // shortcut
             if (logs === null)
@@ -343,6 +336,13 @@ const DataSets = React.createClass({
             else
                 return logs.map(LogEntry);
         };
+
+        const helpActions = [
+            <FlatButton
+                label={this.tr("close")}
+                onClick={this._closeHelp}
+            />,
+        ];
 
         const renderHelp = () => (
             <div style={{float: 'right'}}>

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -145,7 +145,7 @@ const DataSets = React.createClass({
             const title = this.tr("logs") + " (" + datasets.map(ds => ds.id).join(", ") + ")";
             this.setState({
                 logsObject: title,
-                logs: this.tr("logs_loading"),  // show while loading
+                logs: null,
             });
             getLogs().then(logs => {
                 const idsSelected = new Set(datasets.map(ds => ds.id));
@@ -184,7 +184,7 @@ const DataSets = React.createClass({
         const title = this.tr("logs") + " (" + this.tr("all") + ")";
         this.setState({
             logsObject: title,
-            logs: this.tr("logs_loading"),  // show while loading
+            logs: null,
         });
         getLogs().then(logs => {
             this.setState({logs: _(logs).orderBy('date', 'desc').value()});
@@ -334,6 +334,16 @@ const DataSets = React.createClass({
             />,
         ];
 
+        const renderLogs = () => {
+            const logs = this.state.logs;  // shortcut
+            if (logs === null)
+                return this.tr("logs_loading");
+            else if (_(logs).isEmpty())
+                return this.tr("logs_none");
+            else
+                return logs.map(LogEntry);
+        };
+
         const renderHelp = () => (
             <div style={{float: 'right'}}>
                 <IconButton tooltip={this.tr("help")} onClick={this._openHelp}>
@@ -423,10 +433,7 @@ const DataSets = React.createClass({
                                 onRequestClose={listActions.hideLogs}
                                 autoScrollBodyContent={true}
                             >
-                                {
-                                    !_(this.state.logs).isEmpty() ?
-                                        this.state.logs.map(LogEntry)
-                                    : this.tr("logs_none") }
+                                { renderLogs() }
                             </Dialog>)
                         : null }
                 </div>

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -138,13 +138,17 @@ const DataSets = React.createClass({
         if (!datasets) {
             this.setState({logsObject: null});
         } else {
+            const title = this.getTranslation("logs") + " (" + datasets.map(ds => ds.id).join(", ") + ")";
+            this.setState({
+                logsObject: title,
+                logs: this.getTranslation("logs_loading"),  // show while loading
+            });
             getLogs().then(logs => {
                 const idsSelected = new Set(datasets.map(ds => ds.id));
                 const hasIds = (log) => log.datasets.some(ds => idsSelected.has(ds.id));
                 const logsSelected = _(logs).filter(hasIds).orderBy('date', 'desc').value();
-                this.setState({logs: logsSelected.map(LogEntry)});
+                this.setState({logs: logsSelected});
             });
-            this.setState({logsObject: datasets.map(ds => ds.id).join(", "), logs: this.getTranslation("logs_loading")});  // description of what it has
         }
     },
 
@@ -173,10 +177,14 @@ const DataSets = React.createClass({
     openLogs() {
         // Retrieve the logs and save them in this.state.logs, and set
         // this.state.logsObject to a description of their contents.
-        getLogs().then(logs => {
-            this.setState({logs: _(logs).orderBy('date', 'desc').value().map(LogEntry)});
+        const title = this.getTranslation("logs") + " (" + this.getTranslation("all") + ")";
+        this.setState({
+            logsObject: title,
+            logs: this.getTranslation("logs_loading"),  // show while loading
         });
-        this.setState({logsObject: this.getTranslation("all"), logs: this.getTranslation("logs_loading")});  // description of what it has
+        getLogs().then(logs => {
+            this.setState({logs: _(logs).orderBy('date', 'desc').value()});
+        });
     },
 
     onSelectToggle(ev, dataset) {
@@ -393,20 +401,23 @@ const DataSets = React.createClass({
                                 detailsObject={this.state.detailsObject}
                                 onClose={listActions.hideDetailsBox}
                             />
-                        : null}
+                        : null }
                     {
                         this.state.logsObject ? (
                             <Dialog
-                                title={this.getTranslation("logs") + " (" + this.state.logsObject + ")"}
+                                title={this.state.logsObject}
                                 actions={logActions}
                                 open={true}
                                 bodyStyle={{padding: "20px"}}
                                 onRequestClose={listActions.hideLogs}
                                 autoScrollBodyContent={true}
                             >
-                                {_(this.state.logs).isEmpty() ? this.getTranslation('logs_none') : this.state.logs}
+                                {
+                                    !_(this.state.logs).isEmpty() ?
+                                        this.state.logs.map(LogEntry)
+                                        : this.getTranslation("logs_none") }
                             </Dialog>)
-                        : null}
+                        : null }
                 </div>
 
                 {userCanCreateDataSets && <ListActionBar route="datasets/add" />}

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -192,7 +192,10 @@ const DataSets = React.createClass({
     },
 
     addLogPage() {
+        // Placeholder for a function that will add another page to
+        // the already stored logs.
         getLogs([-2]).then(logs => {
+            // TODO: instead of "-2", get the page previous to the last one retrieved.
             logs = [].concat(this.state.logs, logs);
             this.setState({logs: _(logs).orderBy('date', 'desc').value()});
         });

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -187,6 +187,13 @@ const DataSets = React.createClass({
         });
     },
 
+    addLogPage() {
+        getLogs([-2]).then(logs => {
+            logs = [].concat(this.state.logs, logs);
+            this.setState({logs: _(logs).orderBy('date', 'desc').value()});
+        });
+    },
+
     onSelectToggle(ev, dataset) {
         ev.preventDefault();
         ev.stopPropagation();

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -74,6 +74,10 @@ const DataSets = React.createClass({
         };
     },
 
+    tr(text) {
+        return this.getTranslation(text);  // so it's less verbose
+    },
+
     getInitialState() {
         const settings = new Settings(this.context.d2);
 
@@ -138,10 +142,10 @@ const DataSets = React.createClass({
         if (!datasets) {
             this.setState({logsObject: null});
         } else {
-            const title = this.getTranslation("logs") + " (" + datasets.map(ds => ds.id).join(", ") + ")";
+            const title = this.tr("logs") + " (" + datasets.map(ds => ds.id).join(", ") + ")";
             this.setState({
                 logsObject: title,
-                logs: this.getTranslation("logs_loading"),  // show while loading
+                logs: this.tr("logs_loading"),  // show while loading
             });
             getLogs().then(logs => {
                 const idsSelected = new Set(datasets.map(ds => ds.id));
@@ -177,10 +181,10 @@ const DataSets = React.createClass({
     openLogs() {
         // Retrieve the logs and save them in this.state.logs, and set
         // this.state.logsObject to a description of their contents.
-        const title = this.getTranslation("logs") + " (" + this.getTranslation("all") + ")";
+        const title = this.tr("logs") + " (" + this.tr("all") + ")";
         this.setState({
             logsObject: title,
-            logs: this.getTranslation("logs_loading"),  // show while loading
+            logs: this.tr("logs_loading"),  // show while loading
         });
         getLogs().then(logs => {
             this.setState({logs: _(logs).orderBy('date', 'desc').value()});
@@ -299,7 +303,7 @@ const DataSets = React.createClass({
 
         const renderSettingsButton = () => (
             <div style={{float: 'right'}}>
-                <IconButton onTouchTap={this.openSettings} tooltip={this.getTranslation('settings')}>
+                <IconButton onTouchTap={this.openSettings} tooltip={this.tr("settings")}>
                   <SettingsIcon />
                 </IconButton>
             </div>
@@ -307,7 +311,7 @@ const DataSets = React.createClass({
 
         const renderLogsButton = () => (
             <div style={{float: 'right'}}>
-                <IconButton tooltip={this.getTranslation("logs")} onClick={this.openLogs}>
+                <IconButton tooltip={this.tr("logs")} onClick={this.openLogs}>
                     <ListIcon />
                 </IconButton>
             </div>
@@ -318,21 +322,21 @@ const DataSets = React.createClass({
 
         const logActions = [
             <FlatButton
-                label={this.getTranslation('close')}
+                label={this.tr("close")}
                 onClick={listActions.hideLogs}
             />,
         ];
 
         const helpActions = [
             <FlatButton
-                label={this.getTranslation('close')}
+                label={this.tr("close")}
                 onClick={this._closeHelp}
             />,
         ];
 
         const renderHelp = () => (
             <div style={{float: 'right'}}>
-                <IconButton tooltip={this.getTranslation("help")} onClick={this._openHelp}>
+                <IconButton tooltip={this.tr("help")} onClick={this._openHelp}>
                     <HelpOutlineIcon />
                 </IconButton>
             </div>
@@ -341,12 +345,12 @@ const DataSets = React.createClass({
         return (
             <div>
                 <Dialog
-                    title={this.getTranslation('help')}
+                    title={this.tr("help")}
                     actions={helpActions}
                     open={this.state.helpOpen}
                     onRequestClose={this._closeHelp}
                 >
-                    {this.getTranslation("help_landing_page")}
+                    {this.tr("help_landing_page")}
                 </Dialog>
                 <SettingsDialog open={this.state.settingsOpen} onRequestClose={this.closeSettings} />
                 {this.state.orgUnits ? <OrgUnitsDialog
@@ -374,7 +378,7 @@ const DataSets = React.createClass({
                     <div style={{ float: 'left', width: '75%' }}>
                         <SearchBox searchObserverHandler={this.searchListByName}/>
                     </div>
-                    {this.getTranslation("help_landing_page") != '' && renderHelp()}
+                    {this.tr("help_landing_page") != '' && renderHelp()}
                     {this.state.currentUserHasAdminRole && renderLogsButton()}
                     {this.state.currentUserHasAdminRole && renderSettingsButton()}
                     <div>
@@ -422,7 +426,7 @@ const DataSets = React.createClass({
                                 {
                                     !_(this.state.logs).isEmpty() ?
                                         this.state.logs.map(LogEntry)
-                                        : this.getTranslation("logs_none") }
+                                    : this.tr("logs_none") }
                             </Dialog>)
                         : null }
                 </div>

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -74,8 +74,8 @@ const DataSets = React.createClass({
         };
     },
 
-    tr(text) {
-        return this.getTranslation(text);  // so it's less verbose
+    tr(text, variables={}) {
+        return this.getTranslation(text, variables);  // so it's less verbose
     },
 
     getInitialState() {

--- a/src/DataSets/log.js
+++ b/src/DataSets/log.js
@@ -11,7 +11,7 @@ async function log(actionName, status, datasets) {
     const store = await getStore();
     const logs = await getLogs([0], store);
     logs.push(await makeEntry(actionName, status, datasets));
-    setLogs(logs, store);
+    return setLogs(logs, store);
 }
 
 async function getStore() {
@@ -54,13 +54,15 @@ async function setLogs(logs, store) {
     // Save the given list of logs in the current page index and
     // update the page index.
     const logsPageCurrent = await store.get('logs-page-current').catch(() => 0);
-    store.set('logs-page-' + logsPageCurrent, logs);
-    store.set('logs-page-current', logs.length < maxLogsPerPage ?
-              logsPageCurrent : mod(logsPageCurrent + 1, maxLogPages));
+    return Promise.all([
+        store.set('logs-page-' + logsPageCurrent, logs),
+        store.set('logs-page-current', logs.length < maxLogsPerPage ?
+                  logsPageCurrent : mod(logsPageCurrent + 1, maxLogPages)),
+        ]);
 }
 
 function mod(n, m) {
-    return ((n % m) + m) % m;  // the modulo operation can be negative...
+    return ((n % m) + m) % m;  // the modulo operation can be negative otherwise...
 }
 
 // Simple component to show a log entry.

--- a/src/DataSets/log.js
+++ b/src/DataSets/log.js
@@ -42,7 +42,7 @@ async function getLogs(pages, store) {
     const logsPageCurrent = await get('logs-page-current', 0, store);
     const pagesNames = pages.map(n => 'logs-page-' + mod(logsPageCurrent + n, maxLogPages));
     const logs = await Promise.all(pagesNames.map(name => get(name, [], store)));
-    return [].concat(...logs);
+    return _.flatten(logs);
 }
 
 async function setLogs(logs, store) {

--- a/src/DataSets/log.js
+++ b/src/DataSets/log.js
@@ -10,11 +10,11 @@ async function log(actionName, status, datasets) {
     // ("success", "failed"), by whom and on which datasets.
     const store = await getStore();
     const logs = await getLogs([0], store);
-    logs.push(await logEntry(actionName, status, datasets));
+    logs.push(await makeEntry(actionName, status, datasets));
     setLogs(logs, store);
 }
 
-async function logEntry(actionName, status, datasets) {
+async function makeEntry(actionName, status, datasets) {
     // Return an object (a "dictionary") with the information we want to log.
     datasets = Array.isArray(datasets) ? datasets : [datasets];
     const user = await getD2().then(d2 => d2.currentUser);

--- a/src/DataSets/log.js
+++ b/src/DataSets/log.js
@@ -50,19 +50,21 @@ async function setLogs(logs, store) {
     // increase it if necessary.
     const logsPageCurrent = await get('logs-page-current', 0, store);
     store.set('logs-page-' + logsPageCurrent, logs);
-    if (logs.length >= maxLogsPerPage)
+    if (logs.length < maxLogsPerPage)
+        store.set('logs-page-current', logsPageCurrent);  // in case it was not defined
+    else
         store.set('logs-page-current', mod(logsPageCurrent + 1, maxLogPages));
 }
 
-async function get(key, defaultValue, store) {
+function get(key, defaultValue, store) {
     // Return the value for key in the store.
-    return await store.get(key).catch(() => defaultValue);
+    return store.get(key).catch(() => defaultValue);
 }
 
 async function getStore() {
     // Retrieve and return our dataStore.
     const d2 = await getD2();
-    return await d2.dataStore.get('dataset-configuration');
+    return d2.dataStore.get('dataset-configuration');
 }
 
 function mod(n, m) {

--- a/src/DataSets/log.js
+++ b/src/DataSets/log.js
@@ -1,44 +1,73 @@
 import React from 'react';
 import { getInstance as getD2 } from 'd2/lib/d2';
 
+const maxLogsPerPage = 200;  // TODO: maybe make it readable from the dataStore
+const maxLogPages = 100;
 
-async function log(actionName, status, dataset) {
+
+async function log(actionName, status, datasets) {
     // Log the name of the action that has been executed, its status
     // ("success", "failed"), by whom and on which datasets.
-    const maxLogs = 1e3;
+    const store = await getStore();
+    const logs = await getLogs([0], store);
+    logs.push(await logEntry(actionName, status, datasets));
+    setLogs(logs, store);
+}
 
-    const d2 = await getD2();
-    const store = await d2.dataStore.get('dataset-configuration');
-
-    const logIndex = await store.get('logIndex').catch(() => 0);
-    const logs = await store.get('logs').catch(() => []);
-
-    const datasets = Array.isArray(dataset) ? dataset : [dataset];
-
-    const newLog = {
+async function logEntry(actionName, status, datasets) {
+    // Return an object (a "dictionary") with the information we want to log.
+    datasets = Array.isArray(datasets) ? datasets : [datasets];
+    const user = await getD2().then(d2 => d2.currentUser);
+    return {
         date: new Date().toISOString(),
         action: actionName,
         status: status,
-        user: {displayName: d2.currentUser.name,
-               username: d2.currentUser.username,
-               id: d2.currentUser.id},
-        datasets: datasets.map(ds => ({displayName: ds.name, id: ds.id})),
+        user: {
+            displayName: user.name,
+            username: user.username,
+            id: user.id,
+        },
+        datasets: datasets.map(ds => ({
+            displayName: ds.name,
+            id: ds.id,
+        })),
     };
-
-    if (logs.length < maxLogs)
-        logs.push(newLog)
-    else
-        logs[logIndex] = newLog;
-
-    store.set('logIndex', (logIndex + 1) % maxLogs);
-    store.set('logs', logs);
 }
 
-async function getLogs() {
-    // Return logs if they exist, or an empty list otherwise.
+async function getLogs(pages, store) {
+    // Return the concatenated logs for the given pages (relative to
+    // logsPageCurrent) if they exist, or an empty list otherwise.
+    pages = pages || [-1, 0];
+    store = store ? store : await getStore();
+    const logsPageCurrent = await get('logs-page-current', 0, store);
+    const pagesNames = pages.map(n => 'logs-page-' + mod(logsPageCurrent + n, maxLogPages));
+    const logs = await Promise.all(pagesNames.map(name => get(name, [], store)));
+    return [].concat(...logs);
+}
+
+async function setLogs(logs, store) {
+    // Save the given list of logs in the current page index and
+    // increase it if necessary.
+    const logsPageCurrent = await get('logs-page-current', 0, store);
+    store.set('logs-page-' + logsPageCurrent, logs);
+    if (logs.length >= maxLogsPerPage)
+        store.set('logs-page-current', mod(logsPageCurrent + 1, maxLogPages));
+}
+
+async function get(key, defaultValue, store) {
+    // Return the value for key in the store.
+    return await store.get(key).catch(() => defaultValue);
+}
+
+async function getStore() {
+    // Retrieve and return our dataStore.
     const d2 = await getD2();
-    const store = await d2.dataStore.get('dataset-configuration');
-    return store.get('logs').catch(() => []);
+    return await d2.dataStore.get('dataset-configuration');
+}
+
+function mod(n, m) {
+    return ((n % m) + m) % m;
+    // Because javascript is retarded and the modulo operation can be negative.
 }
 
 // Simple component to show a log entry.


### PR DESCRIPTION
This PR adds the capability to use paging for the logs.

At this moment, only the last two pages are retrieved, but the circular buffer for the log pages works, so the structure shouldn't change once we add the visualization of arbitrary pages to the Log Dialog.

I'd like to make this PR even before finishing the viewing part of the pages in the dialog so as to get your early feedback: do you think this paging approach makes sense? do you have a preference as to how to show the pages in the dialog?