### PR TITLE
Use indicator displayName instead of code as group title in custom form

### DIFF
--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -306,7 +306,7 @@ const getOutcomeSection = (opts) => {
             sectionName: sectionName,
             coreCompetency: coreCompetency,
             theme: theme ? theme.displayName : null,
-            group: group ? group.value : indicator.code,
+            group: group ? group.value : indicator.displayName,
             categoryCombo: null,
             selected: origin && origin.id === mandatoryIndicatorId && statusKey === "active",
             origin: origin ? origin.displayName : null,


### PR DESCRIPTION
Closes #319 

![screenshot from 2018-05-23 13-05-30](https://user-images.githubusercontent.com/24643/40420875-17ff34e6-5e8a-11e8-992a-9afc7c6a2d53.png)
