### PR TITLE
Refactor/initial configuration request

### DIFF
--- a/src/DataSets/Forms/InitialConfig.component.js
+++ b/src/DataSets/Forms/InitialConfig.component.js
@@ -48,7 +48,7 @@ const InitialConfig = React.createClass({
             "displayName",
             "startDate",
             "endDate",
-            "organisationUnits[:all]",
+            "organisationUnits[id,path,displayName]",
         ];
         return this._getCategoryOptions(this.props.config.categoryProjectsId, fields);
     },


### PR DESCRIPTION
(To be merged after #358)

The initial step performs a heavy request to get the orgUnits for the projects. This commit restricts the fields we get for the orgUnits to reduce the size of the response. A more complex option would be: don't get orgUnits info at all to render the projects selector component, only when the projected is selected.

