### PR TITLE
Add async validation for dataset name uniqueness

### DIFF
--- a/src/DataSets/Forms/GeneralInformation.component.js
+++ b/src/DataSets/Forms/GeneralInformation.component.js
@@ -63,6 +63,9 @@ const GeneralInformation = React.createClass({
         if (existsDataSetWithName) {
             throw this.getTranslation("dataset_name_exists");
         }
+        else{
+            this.setState({ error: null });
+        }
     },
 
     _renderForm() {

--- a/src/DataSets/Forms/GeneralInformation.component.js
+++ b/src/DataSets/Forms/GeneralInformation.component.js
@@ -10,6 +10,12 @@ import { currentUserHasAdminRole } from "../../utils/Dhis2Helpers";
 const GeneralInformation = React.createClass({
     mixins: [Translate],
 
+    styles: {
+        error: {
+            color: "red",
+        },
+    },
+
     propTypes: {
         config: React.PropTypes.object,
         store: React.PropTypes.object,
@@ -19,6 +25,7 @@ const GeneralInformation = React.createClass({
 
     getInitialState() {
         return {
+            error: null,
             isLoading: true,
             currentUserHasAdminRole: currentUserHasAdminRole(this.context.d2),
         };
@@ -45,8 +52,22 @@ const GeneralInformation = React.createClass({
         this.props.onFieldsChange(fieldPath, newValue);
     },
 
+    async _validateNameUniqueness(name) {
+        const dataSets = await this.context.d2.models.dataSets.list({
+            filter: "name:^ilike:" + name,
+        });
+        const existsDataSetWithName = dataSets
+            .toArray()
+            .some(ds => ds.name.toLowerCase() === name.toLowerCase());
+
+        if (existsDataSetWithName) {
+            throw this.getTranslation("dataset_name_exists");
+        }
+    },
+
     _renderForm() {
         const { associations, dataset } = this.props.store;
+        const { error } = this.state;
         const fields = [
             FormHelpers.getTextField({
                 name: "dataset.name",
@@ -59,6 +80,7 @@ const GeneralInformation = React.createClass({
                         message: this.getTranslation(Validators.isRequired.message),
                     },
                 ],
+                asyncValidators: [name => this._validateNameUniqueness(name)],
             }),
 
             FormHelpers.getTextField({
@@ -108,17 +130,39 @@ const GeneralInformation = React.createClass({
         ];
 
         return (
-            <FormBuilder
-                fields={_.compact(fields)}
-                onUpdateField={this._onUpdateField}
-                onUpdateFormStatus={this._onUpdateFormStatus}
-                validateOnRender={this.props.validateOnRender}
-            />
+            <div>
+                {error && <p style={this.styles.error}>{error}</p>}
+                <FormBuilder
+                    fields={_.compact(fields)}
+                    onUpdateField={this._onUpdateField}
+                    onUpdateFormStatus={this._onUpdateFormStatus}
+                    validateOnRender={this.props.validateOnRender}
+                />
+            </div>
         );
     },
 
-    _onUpdateFormStatus(status) {
-        this.props.formStatus(status.valid);
+    async validate() {
+        const { dataset } = this.props.store;
+
+        if (!dataset.name || !dataset.name.trim()) {
+            this.props.formStatus(false);
+        } else {
+            try {
+                await this._validateNameUniqueness(dataset.name);
+                this.props.formStatus(true);
+                this.setState({ error: null });
+            } catch (err) {
+                this.props.formStatus(false);
+                this.setState({ error: err.toString() });
+            }
+        }
+    },
+
+    async componentWillReceiveProps(props) {
+        if (props.validateOnRender) {
+            this.validate();
+        }
     },
 
     render() {

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -197,3 +197,4 @@ display_only_datasets_created_by_app=Only created by the app
 loading=Loading...
 user_access=User access
 user_group_access=User group access
+dataset_name_exists=There is already a dataset with this name

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -197,3 +197,4 @@ display_only_datasets_created_by_app=Only created by the app
 loading=Loading...
 user_access=User access
 user_group_access=User group access
+dataset_name_exists=There is already a dataset with this name

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -197,3 +197,4 @@ display_only_datasets_created_by_app=Solo creados por la aplicación
 loading=Cargando...
 user_access=Acceso de usuarios
 user_group_access=Acceso de grupos de usuario
+dataset_name_exists=Ya existe un dataset con este nombre

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -197,3 +197,4 @@ display_only_datasets_created_by_app=Only created by the app
 loading=Loading...
 user_access=User access
 user_group_access=User group access
+dataset_name_exists=There is already a dataset with this name


### PR DESCRIPTION
= PR. Pull request template

### :pushpin: References

* **Issue:** Closes #369 

### :memo: Implementation

- FormBuilder bites again: we can force sync validations (like we do on render), but not async validations. Workaround: I added the async validations on the field (will be executed on focus out of the field), and also run the validations explicitly when the Next button is pressed. In this last case, the errors are shown above the component (like we do in other steps).

### :art: Screenshots

![Screenshot from 2019-04-12 19-10-41](https://user-images.githubusercontent.com/24643/56054551-6f28e600-5d57-11e9-9f14-8d3b93903026.png)
