### PR TITLE
Exclude core items validations on Sections for users in a configurabl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "0.9.3",
+    "version": "1.0.0",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {

--- a/src/DataSets/Forms/CoreSections.component.js
+++ b/src/DataSets/Forms/CoreSections.component.js
@@ -1,6 +1,8 @@
 import React from "react";
 import Sections from "./Sections.component";
 
-const CoreSections = props => <Sections {...props} type="core" />;
+const excludeErrors = ["core_competency_no_items"];
+
+const CoreSections = props => <Sections {...props} type="core" excludeErrors={excludeErrors} />;
 
 export default CoreSections;

--- a/src/DataSets/Forms/Sections.component.js
+++ b/src/DataSets/Forms/Sections.component.js
@@ -206,6 +206,7 @@ const Sections = React.createClass({
     getInitialState() {
         return {
             isLoading: true,
+            validateCoreSelected: null,
             sections: null, // loaded on componentDidMount
             sidebarOpen: true,
             filters: {},
@@ -214,11 +215,17 @@ const Sections = React.createClass({
         };
     },
 
-    componentDidMount() {
+    async componentDidMount() {
         const { d2 } = this.context;
         const { config } = this.props;
         const { dataset, associations } = this.props.store;
         const { coreCompetencies, initialCoreCompetencies } = associations;
+
+        const { userGroups } = await d2.Api.getApi().get("/me?fields=userGroups[id]");
+        const currentUserInExclusionGroup = userGroups.some(
+            userGroup => userGroup.id === config.exclusionRuleCoreUserGroupId
+        );
+        const validateCoreSelected = this.props.type === "core" && !currentUserInExclusionGroup;
 
         getSections(d2, config, dataset, initialCoreCompetencies, coreCompetencies).then(
             sectionsArray => {
@@ -230,6 +237,7 @@ const Sections = React.createClass({
                     sections: sections,
                     sectionNames: sectionNames,
                     currentSectionName: _.isEmpty(sectionsArray) ? null : sectionsArray[0].name,
+                    validateCoreSelected,
                 });
             }
         );
@@ -241,11 +249,12 @@ const Sections = React.createClass({
             const errorsLimited = _.take(errors, maxMessages);
             const diff = errors.length - errorsLimited.length;
             const items = [
-                errorsLimited.length > 1 ? errorsLimited.map(s => "- " + s) : errorsLimited,
+                errorsLimited,
                 diff > 0 ? [this.getTranslation("more_errors", { n: diff })] : [],
             ];
             return _(items)
                 .flatten()
+                .map("message")
                 .join("\n");
         };
 
@@ -258,9 +267,18 @@ const Sections = React.createClass({
                 this.state.sections
             );
             store.dataset = dataset;
-            const isValid = _(errors).isEmpty();
+
+            const errors2 =
+                this.props.type === "nonCore"
+                    ? errors
+                    : errors.filter(error => error.key !== "core_competency_no_items");
+            const errors3 = this.state.validateCoreSelected
+                ? errors2
+                : errors2.filter(error => error.key !== "core_competency_no_core_items");
+
+            const isValid = _(errors3).isEmpty();
             if (showErrors && !isValid) {
-                snackActions.show({ message: getErrorMessage(errors) });
+                snackActions.show({ message: getErrorMessage(errors3) });
             }
             return isValid;
         }

--- a/src/Settings/Settings.component.js
+++ b/src/Settings/Settings.component.js
@@ -60,6 +60,7 @@ const SettingsDialog = React.createClass({
                 "dataElementGroupSetStatusId",
                 "indicatorGroupSetStatusId",
                 "hideInDataSetAppAttributeId",
+                "exclusionRuleCoreUserGroupId",
             ],
         },
     },

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -155,6 +155,7 @@ setting_organisation_unit_level_for_countries_id=Country organisation unit level
 setting_admin_user_group=Administrator user group
 setting_hide_in_data_set_app_attribute_id=Hide in dataset attribute
 setting_created_by_data_set_configuration_attribute_id=Created by Dataset Configuration attribute
+setting_exclusion_rule_core_user_group_id=User group excluded of selecting core items
 sharing_countries_description=Please select the regions you want to share this dataset with
 sharing_warning=Note that, if modified, your sharing settings will also be changed
 confirm_delete_dataset=Are you sure you want to delete this/those dataset(s)?

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -155,6 +155,7 @@ setting_organisation_unit_level_for_countries_id=Country organisation unit level
 setting_admin_user_group=Administrator user group
 setting_hide_in_data_set_app_attribute_id=Hide in dataset attribute
 setting_created_by_data_set_configuration_attribute_id=Created by Dataset Configuration attribute
+setting_exclusion_rule_core_user_group_id=User group excluded of selecting core items
 sharing_countries_description=Please select the regions you want to share this dataset with
 sharing_warning=Note that, if modified, your sharing settings will also be changed
 confirm_delete_dataset=Are you sure you want to delete this/those dataset(s)?

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -155,6 +155,7 @@ setting_organisation_unit_level_for_countries_id=Nivel organizativo de país
 setting_admin_user_group=Grupo de usuario con derechos administrativos
 setting_hide_in_data_set_app_attribute_id=Atributo de ocultación en dataset
 setting_created_by_data_set_configuration_attribute_id=Creado por Dataset Configuration (atributo)
+setting_exclusion_rule_core_user_group_id=Grupo de usuario excluido de seleccionar elementos básicos
 sharing_countries_description=Por favor, selecciona las regiones con las que quieres compartir el dataset
 sharing_warning=Nota: si modifica este campo, la configuración de compartición también cambiará
 confirm_delete_dataset=¿Estás seguro de que quieres eliminar este(os) dataset?

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -157,6 +157,7 @@ setting_hide_in_data_set_app_attribute_id=Hide in dataset attribute
 setting_created_by_data_set_configuration_attribute_id=Created by Dataset Configuration attribute
 sharing_countries_description=Please select the regions you want to share this dataset with
 sharing_warning=Note that, if modified, your sharing settings will also be changed
+setting_exclusion_rule_core_user_group_id=User group excluded of selecting core items
 confirm_delete_dataset=Are you sure you want to delete this/those dataset(s)?
 dataset_deleted=Dataset(s) deleted
 this_and_n_others=$$this$$ and $$n$$ others

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -115,6 +115,12 @@ export default class Settings {
             model: "attributes",
             defaultFilter: "code:eq:GL_CREATED_BY_DATASET_CONFIGURATION",
         },
+        {
+            name: "exclusionRuleCoreUserGroupId",
+            type: "d2-object",
+            model: "userGroup",
+            defaultFilter: "name:eq:GL_AllAdmins",
+        },
     ];
 
     constructor(d2) {


### PR DESCRIPTION
…e group= PR. Pull request template

### :pushpin: References

* **Issue:** Closes #367 

### :memo: Implementation

- It was simple to add a setting, so the user group is configurable.
- Validations Core sections (step 4): check if some core selected (unless current user in the exclusion group)
- Validations Non-Core sections (step 5): check if some selected (of any type)

### :art: Screenshots

![Screenshot from 2019-04-12 20-21-14](https://user-images.githubusercontent.com/24643/56057984-8e784100-5d60-11e9-90f0-b7d9ccbb0bae.png)
