### PR TITLE
Update to latest d2-ui#dataset-configuration branch

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,7 +1725,7 @@ d2-manifest@^1.0.0:
 
 "d2-ui@github:EyeSeeTea/d2-ui#dataset-configuration":
   version "26.1.7"
-  resolved "https://codeload.github.com/EyeSeeTea/d2-ui/tar.gz/cfb9f581da3efd4c03c921edc51eb2f9596d65c8"
+  resolved "https://codeload.github.com/EyeSeeTea/d2-ui/tar.gz/3315de041b82c1f0f7230f2afa933c282fc4d7e8"
 
 d2-utilizr@^0.2.9:
   version "0.2.13"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Related #365

### :memo: Implementation

- We use the github source for d2-ui, branch dataset-configuration. I updated to last version in yarn.lock.

### :fire: Tester

1. There is a known bug with yarn, that old versions of gihub packages will be installed in node_modules. If you think this may be the case, clean the global cache and re-install: 

```
$ yarn cache clean
$ rm -rf node_modules/d2-ui 
$ yarn install --check-files
```
2. I had problems with sass in latest versions of node. If that happens to you, install a nodeenv with a 8.x version for example:  `nodeenv --node=8.15.1 ../env-8` and activate prior to installing or starting the server.