### PR TITLE
Fix/period dates details

### DIFF
--- a/src/DataSets/Forms/GeneralInformation.component.js
+++ b/src/DataSets/Forms/GeneralInformation.component.js
@@ -123,7 +123,7 @@ const GeneralInformation = React.createClass({
                     getDateField({
                         name: `associations.periodDates.${type}.${year}.end`,
                         value: _(periodDates).get([type, year, "end"]),
-                        label: t(`${type}_start_date`) + " " + year,
+                        label: t(`${type}_end_date`) + " " + year,
                         minDate: startDate,
                         disabled,
                         wrapStyle: this.styles.dateFieldWrapStyle,

--- a/src/forms/form-fields/date-select.js
+++ b/src/forms/form-fields/date-select.js
@@ -37,7 +37,9 @@ export default React.createClass({
             ...other
         } = this.props;
 
-        const valueProp = value ? { value: new Date(value) } : {};
+        // Set the empty string instead of undefined for the no-value case, otherwise the component
+        // assumes it's being used in un-controlled state and does not react properly to changes
+        const valueProp = value ? { value: new Date(value) } : { value: "" };
 
         return (
             <DatePicker

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -210,4 +210,4 @@ apply_periods_to_all=Apply same dates for every year
 output_dates=Output Dates
 outcome_dates=Outcomes Dates
 start_date_before_project_start=Start date should be after the start of the project
-current_date_out_of_period=The selected period is outside the accepted range
+current_date_out_of_period=Current date out of accepted period

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -210,4 +210,4 @@ apply_periods_to_all=Apply same dates for every year
 output_dates=Output Dates
 outcome_dates=Outcome Dates
 start_date_before_project_start=Start date should be after the start of the project
-current_date_out_of_period=The selected period is outside the accepted range
+current_date_out_of_period=Current date out of accepted period

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -210,4 +210,4 @@ apply_periods_to_all=Aplica las mismas fechas para todos los años
 output_dates=Salida - Fechas
 outcome_dates=Resultados - Fechas
 start_date_before_project_start=La fecha de inicio debe ser posterior al inicio del proyecto
-current_date_out_of_period=No se pueden introducir datos para el periodo seleccionado
+current_date_out_of_period=La fecha actual está fuera del periodo válido

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -210,4 +210,4 @@ apply_periods_to_all=Apply same dates for every year
 output_dates=Output Dates
 outcome_dates=Outcomes Dates
 start_date_before_project_start=Start date should be after the start of the project
-current_date_out_of_period=The selected period is outside the accepted range
+current_date_out_of_period=Current date out of accepted period

--- a/src/models/custom-form-resources/script.js
+++ b/src/models/custom-form-resources/script.js
@@ -348,7 +348,8 @@ function setPeriodDates(periodDates_) {
         const selectedPeriod = dhis2.de.getSelectedPeriod();
         if (!selectedPeriod || !selectedPeriod.startDate) return;
         const getDate = isoDate => (isoDate ? new Date(isoDate.split("T")[0]) : null);
-        const getFormatDate = isoDate => (isoDate ? formatDate(new Date(isoDate.split("T")[0]), "dd/MM/yyyy") : null);
+        const getFormatDate = isoDate =>
+            isoDate ? formatDate(new Date(isoDate.split("T")[0]), "dd/MM/yyyy") : null;
         const startDate = selectedPeriod.startDate;
         const periodYear = startDate.split("-")[0];
         const today = new Date();
@@ -358,10 +359,9 @@ function setPeriodDates(periodDates_) {
             const obj = (periodDates[type] || {})[periodYear];
             const ns = { from: getFormatDate(obj.start) || "-", to: getFormatDate(obj.end) || "-" };
             const info = `${ns.from} -> ${ns.to}`;
-           
+
             const isDateOutsidePeriod =
-                (obj.start && today < getDate(obj.start)) ||
-                (obj.end && today > getDate(obj.end));
+                (obj.start && today < getDate(obj.start)) || (obj.end && today > getDate(obj.end));
 
             setTabsVisibility(type, isDateOutsidePeriod, info);
         });


### PR DESCRIPTION
### :pushpin: References

Fixes:

- A delay on date changes when starting unset. The problem was: as the initial value was not set, the material-ui component thinks it's in an uncontrolled state.
- Fix custom form period literal.
- Fix end date label.

