### PR TITLE
[custom form] Add CSS for indicator name so the width is adjusted (like DEs)

### DIFF
--- a/src/models/custom-form-resources/sectionForm.vm
+++ b/src/models/custom-form-resources/sectionForm.vm
@@ -11,7 +11,7 @@
                     #end
 
                     <tr>
-                        <td #if( $mark == 1 )class="alt"#else class="reg"#end>
+                        <td #if( $mark == 1 )class="alt nrcindicatorName"#else class="reg nrcindicatorName"#end>
                             <span>$indicator.displayName</span>
                         </td>
 


### PR DESCRIPTION
Fixes #383 

Add CSS class like we do in data elements.

Old:

![Screenshot from 2019-05-29 13-42-47](https://user-images.githubusercontent.com/24643/58554600-affd9100-8217-11e9-8901-7f77529c0bca.png)

With the fix:

![image](https://user-images.githubusercontent.com/24643/58554451-3e254780-8217-11e9-90b4-06817026d31c.png)
