### PR TITLE
[Disaggregation] Group non-comment data elements by indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {

--- a/src/DataSets/Forms/Disaggregation.component.js
+++ b/src/DataSets/Forms/Disaggregation.component.js
@@ -6,6 +6,7 @@ import LinearProgress from "material-ui/LinearProgress/LinearProgress";
 import DataSetElementCategoryComboSelectionDialog from "../../forms/DataSetElementCategoryComboSelectionDialog.component";
 import { getCategoryCombos, getDisaggregationForCategories } from "../../utils/Dhis2Helpers";
 import SearchBox from "../../SearchBox/SearchBox.component";
+import { getSections } from "../../models/Section";
 
 const SearchBoxWrapper = props => {
     const { debounce, onChange } = props;
@@ -34,33 +35,63 @@ const Disaggregation = React.createClass({
     getInitialState() {
         return {
             categoryCombos: null,
+            dataSetElementsGroups: null,
             filter: "",
         };
     },
 
-    componentDidMount() {
-        getCategoryCombos(this.context.d2).then(categoryCombos => {
-            this.setState({
-                categoryCombos: categoryCombos.toArray(),
-            });
-        });
+    async componentDidMount() {
+        Promise.all([getCategoryCombos(this.context.d2), this._getDataSetElementsGroups()]).then(
+            ([categoryCombos, dataSetElementsGroups]) => {
+                this.setState({
+                    categoryCombos: categoryCombos.toArray(),
+                    dataSetElementsGroups,
+                });
+            }
+        );
     },
 
     componentWillReceiveProps(props) {
         if (props.validateOnRender) props.formStatus(true);
     },
 
-    _onCategoriesSelected(dataSetElementId, categories) {
+    async _getDataSetElementsGroups() {
+        const { d2 } = this.context;
+        const { config } = this.props;
+        const { dataset, associations } = this.props.store;
+        const { coreCompetencies: ccs, initialCoreCompetencies: initialCcs } = associations;
+        const sections = await getSections(d2, config, dataset, initialCcs, ccs);
+
+        const indicatorIdsByDeId = _(sections)
+            .flatMap(section => _.values(section.items))
+            .filter(item => item.type === "indicator")
+            .flatMap(indItem => indItem.dataElementsNumeric.map(de => [de.id, indItem.id]))
+            .fromPairs()
+            .value();
+
+        return _(dataset.dataSetElements)
+            .groupBy(dse => indicatorIdsByDeId[dse.dataElement.id] || `de-${dse.dataElement.id}`)
+            .values()
+            .sortBy(dseGroup => dseGroup[0].dataElement.displayName)
+            .value();
+    },
+
+    _onCategoriesSelected(dataSetElementIds, categories) {
+        const { d2 } = this.context;
         const { dataSetElements } = this.props.store.dataset;
-        const dataSetElementToUpdate = _(dataSetElements).find(dse => dse.id === dataSetElementId);
-        const { dataElement } = dataSetElementToUpdate;
-        const customCategoryCombo = getDisaggregationForCategories(
-            this.context.d2,
-            dataElement,
-            this.state.categoryCombos,
-            categories
-        );
-        dataSetElementToUpdate.categoryCombo = customCategoryCombo;
+        const { categoryCombos } = this.state;
+
+        _(dataSetElementIds).each(dseId => {
+            const dataSetElementToUpdate = _(dataSetElements).find(dse => dse.id === dseId);
+            const customCategoryCombo = getDisaggregationForCategories(
+                d2,
+                dataSetElementToUpdate.dataElement,
+                categoryCombos,
+                categories
+            );
+            dataSetElementToUpdate.categoryCombo = customCategoryCombo;
+        });
+
         this.forceUpdate();
     },
 
@@ -70,13 +101,14 @@ const Disaggregation = React.createClass({
 
     _renderForm() {
         const d2 = this.context.d2;
-        const { dataSetElements } = this.props.store.dataset;
-        const { categoryCombos, filter } = this.state;
+        const { categoryCombos, filter, dataSetElementsGroups } = this.state;
         const isSubstring = (s1, s2) => _.includes(s1.toLowerCase(), s2.toLowerCase());
-        const filteredDataSetElements = dataSetElements.filter(
-            dse => !filter || isSubstring(dse.dataElement.displayName, filter)
-        );
         const canEdit = d2.currentUser.canCreate(d2.models.categoryCombos);
+        const dataSetElementsGroupsFiltered = filter
+            ? dataSetElementsGroups.filter(dseGroup =>
+                  dseGroup.some(dse => isSubstring(dse.dataElement.displayName, filter))
+              )
+            : dataSetElementsGroups;
 
         return (
             <div>
@@ -89,7 +121,7 @@ const Disaggregation = React.createClass({
                 <SearchBoxWrapper onChange={this._onSearchChange} />
 
                 <DataSetElementCategoryComboSelectionDialog
-                    dataSetElements={filteredDataSetElements}
+                    dataSetElementsGroups={dataSetElementsGroupsFiltered}
                     categoryCombos={categoryCombos}
                     onCategoriesSelected={this._onCategoriesSelected}
                     d2={d2}
@@ -100,7 +132,11 @@ const Disaggregation = React.createClass({
     },
 
     render() {
-        return !this.state.categoryCombos ? <LinearProgress /> : <div>{this._renderForm()}</div>;
+        return !this.state.categoryCombos || !this.state.dataSetElementsGroups ? (
+            <LinearProgress />
+        ) : (
+            <div>{this._renderForm()}</div>
+        );
     },
 });
 

--- a/src/forms/DataSetElementCategoryComboSelectionDialog.component.js
+++ b/src/forms/DataSetElementCategoryComboSelectionDialog.component.js
@@ -104,6 +104,7 @@ function DataSetElementList(
 ) {
     const styles = {
         elementListItem: { width: "49%" },
+        elementListItemDataElement: { width: "49%", marginTop: "2.5%" },
         noDataElementMessage: { paddingTop: "2rem" },
         originalCategoryCombo: { color: "#CCC", fontSize: "1rem", fontWeight: "300" },
     };
@@ -136,7 +137,7 @@ function DataSetElementList(
 
         return (
             <Row key={id} style={{ alignItems: "center", marginBottom: canEdit ? 0 : 10 }}>
-                <div style={styles.elementListItem}>
+                <div style={styles.elementListItemDataElement}>
                     {dseGroup.map(dse => (
                         <div key={dse.id}>{dse.dataElement.displayName}</div>
                     ))}

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -440,6 +440,7 @@ const getOutcomeSection = opts => {
             dataElements: dataElements.map(de =>
                 _.assign(getOwnedPropertyJSON(de), { displayName: de.displayName })
             ),
+            dataElementsNumeric: dataElements.filter(de => de.code && !de.code.endsWith("-C")),
             id: indicator.id,
             code: indicator.code,
             name: indicator.name,

--- a/src/models/custom-form-resources/script.js
+++ b/src/models/custom-form-resources/script.js
@@ -357,11 +357,13 @@ function setPeriodDates(periodDates_) {
 
         ["output", "outcome"].forEach(type => {
             const obj = (periodDates[type] || {})[periodYear];
-            const ns = { from: getFormatDate(obj.start) || "-", to: getFormatDate(obj.end) || "-" };
-            const info = `${ns.from} -> ${ns.to}`;
-
             const isDateOutsidePeriod =
-                (obj.start && today < getDate(obj.start)) || (obj.end && today > getDate(obj.end));
+                obj !== undefined && ((obj.start && today < getDate(obj.start)) || (obj.end && today > getDate(obj.end)));
+            let info;
+            if (isDateOutsidePeriod){
+                const ns = { from: getFormatDate(obj.start) || "-", to: getFormatDate(obj.end) || "-" };
+                info = `${ns.from} -> ${ns.to}`;
+            }
 
             setTabsVisibility(type, isDateOutsidePeriod, info);
         });


### PR DESCRIPTION
Closes #381 

Implementation:

- Group dataElements from the the same indicator, exclude dataElement if its code ends with `-C` (comment). A change of disaggregation affects both.
- On search: Show full group (numerator and denominator, when grouped).

Notes:

On long data element names, we may have a line break because of the length and then another for the second dataelement. Maybe we can add a visual cue.

![image](https://user-images.githubusercontent.com/24643/58619815-f14c7a00-82c5-11e9-972a-79abd748a70c.png)

Filter:

![image](https://user-images.githubusercontent.com/24643/58619997-530ce400-82c6-11e9-8159-6f6fbb34b3e5.png)