### PR TITLE
[security] Update tar/fstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
         "webpack-dev-server": "^1.14.1",
         "webpack-visualizer-plugin": "^0.1.5"
     },
+    "resolutions": {
+        "node-sass/**/fstream": "^1.0.12",
+        "node-sass/**/tar": "^2.2.2"
+    },
     "pre-commit": [
         "test",
         "lint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,7 +2544,17 @@ fstream-ignore@^1.0.5:
     inherits "2"
     minimatch "^3.0.0"
 
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
+fstream@^1.0.0, fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
+fstream@^1.0.10, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -5563,7 +5573,16 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar@^2.0.0, tar@^2.2.1:
+tar@^2.0.0, tar@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
+  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.12"
+    inherits "2"
+
+tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:


### PR DESCRIPTION
https://github.com/EyeSeeTea/dataset-configuration/network/alerts

![image](https://user-images.githubusercontent.com/24643/58706950-b32d8400-83b3-11e9-9bcb-a8c02b3852fd.png)

I tried to fix the webpack-dev-server, but it forces to update 2 major webpack versions, which would require a lot of work to make it work. Since it's low serverity (dev server), I am ignoring it for now.

Some notes:

- I tried the automated fixes by github. Problems: you have to generate one PR for every security, it's better to have an independent way to do it. 
- Done using: `yarn why PACKAGE`  and yarn's [selective resolutions](https://yarnpkg.com/en/docs/selective-version-resolutions)

Let's see if those two alerts disappear after the merge.