### PR TITLE
Feature/prefill dates

### DIFF
--- a/src/DataSets/Forms/GeneralInformation.component.js
+++ b/src/DataSets/Forms/GeneralInformation.component.js
@@ -88,10 +88,13 @@ const GeneralInformation = React.createClass({
             return _.flatMap(years, (year, index) => {
                 const disabled = index > 0 && associations.periodDatesApplyToAll[type];
                 const showApplyToAllYearsCheckbox = index === 0 && years.length > 1;
-                const startDateMom = startDate ? moment(startDate).startOf("day") : null;
                 const validators = [
                     {
-                        validator: value => !value || moment(value).isSameOrAfter(startDateMom),
+                        validator: value => {
+                            const startDate = associations.dataInputStartDate;
+                            const startDateM = startDate ? moment(startDate).startOf("day") : null;
+                            return !value || !startDateM || moment(value).isSameOrAfter(startDateM);
+                        },
                         message: this.getTranslation("start_date_before_project_start"),
                     },
                 ];

--- a/src/forms/form-fields/date-select.js
+++ b/src/forms/form-fields/date-select.js
@@ -37,14 +37,14 @@ export default React.createClass({
             ...other
         } = this.props;
 
-        // Set the empty string instead of undefined for the no-value case, otherwise the component
+        // Set an empty object instead of undefined for the no-value case, otherwise the component
         // assumes it's being used in un-controlled state and does not react properly to changes
-        const valueProp = value ? { value: new Date(value) } : { value: "" };
+        const valueProp = value ? new Date(value) : {};
 
         return (
             <DatePicker
                 {...other}
-                {...valueProp}
+                value={valueProp}
                 mode="portrait"
                 autoOk
                 disabled={disabled}

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -490,6 +490,7 @@ export default class DataSetStore {
                     } = this.getDataFromProject(dataset, associations);
                     this.dataset = newDataset;
                     this.associations = newAssociations;
+                    this.setDefaultPeriodValues();
                 }
                 break;
             case "associations.dataInputStartDate":

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -445,6 +445,38 @@ export default class DataSetStore {
         }
     }
 
+    setDefaultPeriodValues() {
+        const { dataInputStartDate, dataInputEndDate } = this.associations;
+        if (!(dataInputStartDate && dataInputEndDate)) return;
+
+        const years = this.getPeriodYears();
+
+        const getPeriodDates = (years, { month }) =>
+            _(years)
+                .map(year => {
+                    const period = {
+                        start: moment(dataInputStartDate)
+                            .set("year", year)
+                            .toDate(),
+                        end: new Date(year + 1, month - 1, 1),
+                    };
+                    return [year, period];
+                })
+                .fromPairs()
+                .value();
+
+        _.assign(this.associations, {
+            periodDatesApplyToAll: {
+                output: true,
+                outcome: true,
+            },
+            periodDates: {
+                output: getPeriodDates(years, { month: 4 }),
+                outcome: getPeriodDates(years, { month: 5 }),
+            },
+        });
+    }
+
     updateLinkedFields(fieldPath, oldValue) {
         const { dataset, associations } = this;
 
@@ -462,6 +494,7 @@ export default class DataSetStore {
             case "associations.dataInputStartDate":
             case "associations.dataInputEndDate":
                 const { dataInputStartDate, dataInputEndDate } = associations;
+                this.setDefaultPeriodValues();
                 this.dataset.openFuturePeriods = this.getOpenFuturePeriods(dataInputEndDate);
                 this.dataset.dataInputPeriods = this.getDataInputPeriods(
                     dataInputStartDate,

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -455,9 +455,10 @@ export default class DataSetStore {
             _(years)
                 .map(year => {
                     const period = {
-                        start: moment(dataInputStartDate)
-                            .set("year", year)
-                            .toDate(),
+                        start:
+                            dataInputStartDate.getFullYear() === year
+                                ? dataInputStartDate
+                                : new Date(year, 0, 1),
                         end: new Date(year + 1, month - 1, 1),
                     };
                     return [year, period];
@@ -467,8 +468,8 @@ export default class DataSetStore {
 
         _.assign(this.associations, {
             periodDatesApplyToAll: {
-                output: true,
-                outcome: true,
+                output: false,
+                outcome: false,
             },
             periodDates: {
                 output: getPeriodDates(years, { month: 4 }),


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #397

### :memo: Implementation

- The final logic is: Whenever the start of end date are changed and both have values, the period values will be overridden with the specified defaults (alternative: we could override only when we come from an undefined date value, even though it will be a bit cryptic).

- I've added a minor fix to avoid a warning on the console (`Invalid prop `value` of type `string` supplied to `DatePicker`, expected `object``).

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/61126358-88ebdd80-a4ac-11e9-836d-af3728c2dbc1.png)