### PR TITLE
Use toArray wrapper to remove undefined values from d2 collection

### DIFF
--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -5,6 +5,8 @@ import fp from "lodash/fp";
 import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import memoize from "nano-memoize";
 
+const toArray = collectionToArray;
+
 /* Return an array of sections containing its data elements and associated indicators. Schema:
 
     [{
@@ -117,10 +119,10 @@ export const getDataSetInfo = (d2, config, sections) => {
         .map((d2s, index) => _.set(d2s, "sortOrder", index))
         .value();
     const dataElements = _(d2Sections)
-        .flatMap(d2s => d2s.dataElements.toArray())
+        .flatMap(d2s => toArray(d2s.dataElements))
         .value();
     const indicators = _(d2Sections)
-        .flatMap(d2s => d2s.indicators.toArray())
+        .flatMap(d2s => toArray(d2s.indicators))
         .value();
     const dataSetElements = dataElements.map(dataElement => ({
         id: generateUid(),
@@ -356,7 +358,7 @@ const getOutputSection = opts => {
     const sectionName = coreCompetency.name + " Outputs";
     const dataElements = dataElementsByCCId[coreCompetency.id];
     const getDataElementInfo = dataElement => {
-        const groupSets = _(dataElement.dataElementGroups.toArray())
+        const groupSets = _(toArray(dataElement.dataElementGroups))
             .map(deg => [degRelations[deg.id], deg])
             .fromPairs()
             .value();
@@ -418,7 +420,7 @@ const getOutcomeSection = opts => {
     const sectionName = coreCompetency.name + " Outcomes";
     const indicators = indicatorsByGroupName[coreCompetency.name] || [];
     const getIndicatorInfo = (indicator, dataElements) => {
-        const indicatorGroupSets = _(indicator.indicatorGroups.toArray())
+        const indicatorGroupSets = _(toArray(indicator.indicatorGroups))
             .map(ig => [igRelations[ig.id], ig])
             .fromPairs()
             .value();
@@ -524,7 +526,7 @@ const getDeIdsFromFormula = formula => {
 
 const filterDataElements = (dataElements, requiredDegIds) => {
     return dataElements.filter(dataElement => {
-        const degIds = new Set(dataElement.dataElementGroups.toArray().map(deg => deg.id));
+        const degIds = new Set(toArray(dataElement.dataElementGroups).map(deg => deg.id));
         return requiredDegIds.every(requiredDegId => degIds.has(requiredDegId));
     });
 };
@@ -534,8 +536,8 @@ const getDataElementGroupRelations = d2 => {
     return d2.models.dataElementGroupSets
         .list({ fields: "id,displayName,dataElementGroups[id,displayName]" })
         .then(collection =>
-            collection.toArray().map(degSet =>
-                _(degSet.dataElementGroups.toArray())
+            toArray(collection).map(degSet =>
+                _(toArray(degSet.dataElementGroups))
                     .map(deg => [deg.id, degSet.id])
                     .fromPairs()
                     .value()
@@ -549,8 +551,8 @@ const getIndicatorGroupRelations = d2 => {
     return d2.models.indicatorGroupSets
         .list({ fields: "id,displayName,indicatorGroups[id,displayName]" })
         .then(collection =>
-            collection.toArray().map(igSet =>
-                _(igSet.indicatorGroups.toArray())
+            toArray(collection).map(igSet =>
+                _(toArray(igSet.indicatorGroups))
                     .map(ig => [ig.id, igSet.id])
                     .fromPairs()
                     .value()
@@ -645,7 +647,7 @@ const getIndicatorsByGroupName = (d2, coreCompetencies) => {
 
     return getFilteredItems(d2.models.indicatorGroups, filters, { fields }).then(indicatorGroups =>
         _(indicatorGroups)
-            .map(indGroup => [indGroup.displayName, indGroup.indicators.toArray()])
+            .map(indGroup => [indGroup.displayName, toArray(indGroup.indicators)])
             .fromPairs()
             .value()
     );

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -2,6 +2,16 @@ import { generateUid } from "d2/lib/uid";
 import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import _ from "./lodash-mixins";
 
+function collectionToArray(collectionOrArray) {
+    const array =
+        collectionOrArray && collectionOrArray.toArray
+            ? collectionOrArray.toArray()
+            : collectionOrArray || [];
+    return _.compact(array);
+}
+
+const toArray = collectionToArray;
+
 const accesses = {
     none: "--------",
     read: "r-------",
@@ -57,14 +67,8 @@ function getOrgUnitsForLevel(d2, levelId) {
                 order: "displayName:asc",
                 paging: false,
             })
-            .then(collection => collection.toArray().filter(ou => ou.children));
+            .then(collection => toArray(collection).filter(ou => ou.children));
     });
-}
-
-function collectionToArray(collectionOrArray) {
-    return collectionOrArray && collectionOrArray.toArray
-        ? collectionOrArray.toArray()
-        : collectionOrArray || [];
 }
 
 // Keep track of the created categoryCombos so objects are reused
@@ -72,7 +76,7 @@ let cachedCategoryCombos = {};
 
 function getDisaggregationForCategories(d2, dataElement, categoryCombos, categories) {
     const categoriesById = _(categoryCombos)
-        .flatMap(cc => cc.categories.toArray())
+        .flatMap(cc => toArray(cc.categories))
         .uniqBy("id")
         .keyBy("id")
         .value();
@@ -113,7 +117,7 @@ function getDisaggregationForCategories(d2, dataElement, categoryCombos, categor
     } else {
         const newCategoryComboId = generateUid();
         const categories = _.at(categoriesById, combinedCategoriesIds);
-        const categoryOptions = categories.map(c => c.categoryOptions.toArray());
+        const categoryOptions = categories.map(c => toArray(c.categoryOptions));
         const categoryOptionCombos = _.cartesianProduct(...categoryOptions).map(cos => ({
             id: generateUid(),
             name: cos.map(co => co.displayName).join(", "),
@@ -168,7 +172,7 @@ function getExistingUserRoleByName(d2, name) {
         .on("name")
         .equals(name)
         .list({ fields: "*" })
-        .then(collection => collection.toArray()[0]);
+        .then(collection => toArray(collection)[0]);
 }
 
 function getUserGroups(d2, names) {
@@ -222,7 +226,7 @@ function setSharings(d2, objects, userGroupAccessByName) {
     } else {
         const [userGroupNames, userGroupAccesses] = _.zip(...userGroupAccessByName);
         userGroupAccesses$ = getUserGroups(d2, userGroupNames).then(userGroupsCollection =>
-            _(userGroupsCollection.toArray())
+            _(toArray(userGroupsCollection))
                 .keyBy(userGroup => userGroup.name)
                 .at(userGroupNames)
                 .zip(userGroupAccesses)
@@ -353,7 +357,7 @@ function getUids(d2, length) {
 
 function sendMessageToGroups(d2, userGroupNames, title, body) {
     return getUserGroups(d2, userGroupNames)
-        .then(userGroups => sendMessage(d2, title, body, userGroups.toArray()))
+        .then(userGroups => sendMessage(d2, title, body, toArray(userGroups)))
         .catch(_err => {
             alert("Could not send DHIS2 message");
         });
@@ -439,13 +443,11 @@ async function getFilteredDatasets(d2, config, page, sorting, filters) {
             fields: attributeFields,
             paging: false,
         });
-        const datasetsByApp = dataSetsCollectionNoPaging
-            .toArray()
-            .filter(dataset =>
-                _(dataset.attributeValues).some(
-                    av => av.attribute.id === attributeByAppId && av.value.toString() === "true"
-                )
-            );
+        const datasetsByApp = toArray(dataSetsCollectionNoPaging).filter(dataset =>
+            _(dataset.attributeValues).some(
+                av => av.attribute.id === attributeByAppId && av.value.toString() === "true"
+            )
+        );
         const maxUids = (8192 - 1000) / (11 + 3); // To avoid 413 URL too large
         const filters = [
             ...baseFilters,
@@ -465,7 +467,7 @@ async function subQuery(d2, objects, field, subfields) {
         "id:in:[" +
         _(objects)
             .map(obj => obj[field])
-            .flatMap(obj => (obj.toArray ? obj.toArray().map(o => o.id) : [obj.id]))
+            .flatMap(obj => (obj.toArray ? toArray(obj).map(o => o.id) : [obj.id]))
             .uniq()
             .join(",") +
         "]";
@@ -476,14 +478,14 @@ async function subQuery(d2, objects, field, subfields) {
             fields: subfields,
             filter: filter,
         })
-        .then(collection => collection.toArray());
+        .then(collection => toArray(collection));
 
     const subObjectsById = _.keyBy(subObjects, "id");
 
     return objects.map(obj => {
         const value = obj[field];
         obj[field] = value.toArray
-            ? { toArray: () => value.toArray().map(v => subObjectsById[v.id]) }
+            ? { toArray: () => toArray(value).map(v => subObjectsById[v.id]) }
             : subObjectsById[value.id];
         return obj;
     });


### PR DESCRIPTION
Fix error "Section.js:526 Uncaught (in promise) TypeError: Cannot read property 'id' of undefined" due to `dataElement.dataElementGroups.toArray()` returning undefined values in the array. 

Now we use the `collectionToArray` wrapper for all this and other .toArray() accesses to avoid problems.

