### PR TITLE
Clear dataset.dataEntryForm to avoid the form being reused on d2 save

### DIFF
--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -81,6 +81,8 @@ class Factory {
             toArray(dataset.sections).forEach(section => {
                 section.id = undefined;
             });
+            // On dataset clone, the custom form is reused, clear the field explicitly
+            dataset.dataEntryForm = undefined;
             return this.getStore(dataset, "clone");
         });
     }


### PR DESCRIPTION
When a dataset was cloned, the `dataset.save` used the same custom form in DB instead of creating a new one. This fixes the problem.