### PR TITLE
[fix] Use always project.displayName

### DIFF
--- a/src/DataSets/DetailsBox.component.js
+++ b/src/DataSets/DetailsBox.component.js
@@ -1,5 +1,5 @@
 import React from "react";
-import createReactClass from 'create-react-class';
+import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import classes from "classnames";
 import FontIcon from "material-ui/FontIcon";
@@ -99,7 +99,7 @@ export default createReactClass({
                 ),
             linkedProject: () =>
                 getProject(d2, this.props.config, this.props.source).then(project =>
-                    project ? project.name : this.getTranslation("no_project_linked")
+                    project ? project.displayName : this.getTranslation("no_project_linked")
                 ),
         };
     },

--- a/src/DataSets/Forms/Save.component.js
+++ b/src/DataSets/Forms/Save.component.js
@@ -1,5 +1,5 @@
 import React from "react";
-import createReactClass from 'create-react-class';
+import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import _ from "lodash";
 import Translate from "d2-ui/lib/i18n/Translate.mixin";
@@ -110,7 +110,7 @@ const Save = createReactClass({
                         />
                         <ListItem
                             field="linked_project"
-                            value={associations.project && associations.project.name}
+                            value={associations.project && associations.project.displayName}
                         />
                         <ListItem
                             field="orgunits_settings"

--- a/src/models/dataset.js
+++ b/src/models/dataset.js
@@ -29,9 +29,11 @@ export function getProject(d2, config, dataset) {
             .filter()
             .on("categories.id")
             .equals(config.categoryProjectsId)
-            .list({ fields: "id,name", paging: false })
+            .list({ fields: "id,displayName", paging: false })
             .then(collection => collection.toArray())
-            .then(projects => _(projects).find(project => _.includes(dataset.name, project.name)));
+            .then(projects =>
+                _(projects).find(project => _.includes(dataset.name, project.displayName))
+            );
     } else {
         return Promise.resolve(null);
     }


### PR DESCRIPTION
There were some uses of `project.name` and some of `project.displayName`. Let's use always `displayName`.