### PR TITLE
Migration to 2.36

### DIFF
--- a/src/DataSets/DataSetPeriods.js
+++ b/src/DataSets/DataSetPeriods.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import moment from "moment";
 import _ from "lodash";

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -128,9 +128,11 @@ const DataSets = createReactClass({
     },
 
     subscribeToModelStore(store, modelName) {
+        const d2 = this.context.d2;
+
         return store.subscribe(async datasets => {
             if (datasets) {
-                const d2Datasets = await getDataSetsWithOwnerFields(datasets);
+                const d2Datasets = await getDataSetsWithOwnerFields(d2, datasets);
                 this.setState({ [modelName]: { models: d2Datasets } });
             } else {
                 this.setState({ [modelName]: null });
@@ -600,7 +602,7 @@ const DataSets = createReactClass({
     },
 });
 
-function getDataSetsWithOwnerFields(dataSets) {
+function getDataSetsWithOwnerFields(d2, dataSets) {
     const dataSetIds = dataSets.map(o => o.id).join(",");
     return d2.models.dataSets
         // access fields are not in :owner anymore (2.36), ask for them explictly

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -443,7 +443,7 @@ const DataSets = createReactClass({
 
         const showCreatedByAppCheck = !!config.createdByDataSetConfigurationAttributeId;
         const olderLogLiteral = logsPageLast < 0 ? this.tr("logs_no_older") : this.tr("logs_older");
-        const dateString = new Date(logsOldestDate || Date()).toLocaleString();
+        const dateString = new Date(logsOldestDate || new Date()).toLocaleString();
         const label = olderLogLiteral + " " + dateString;
 
         const logLoadMoreButton = logsHasMore ? (

--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -603,8 +603,9 @@ const DataSets = createReactClass({
 function getDataSetsWithOwnerFields(dataSets) {
     const dataSetIds = dataSets.map(o => o.id).join(",");
     return d2.models.dataSets
+        // access fields are not in :owner anymore (2.36), ask for them explictly
         .list({
-            fields: ":owner",
+            fields: ":owner,publicAccess,userAccesses,userGroupAccesses",
             filter: `id:in:[${dataSetIds}]`,
         })
         .then(c => c.toArray());

--- a/src/DataSets/FormSteps.component.js
+++ b/src/DataSets/FormSteps.component.js
@@ -1,6 +1,5 @@
 import React from "react";
 import createReactClass from "create-react-class";
-import PropTypes from "prop-types";
 import _ from "lodash";
 import Translate from "d2-ui/lib/i18n/Translate.mixin";
 import Wizard from "../Wizard/Wizard.component";

--- a/src/DataSets/PeriodsDialog.js
+++ b/src/DataSets/PeriodsDialog.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import _ from "lodash";
 import Dialog from "material-ui/Dialog";

--- a/src/components/sharing-dialog/utils.js
+++ b/src/components/sharing-dialog/utils.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
+import { getOwnedPropertyJSON } from "../../utils/Dhis2Helpers";
 
 export const cachedAccessTypeToString = (canView, canEdit) => {
     if (canView) {

--- a/src/forms/DataInputPeriods.component.js
+++ b/src/forms/DataInputPeriods.component.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import Dialog from "material-ui/Dialog";
 import RaisedButton from "material-ui/RaisedButton";

--- a/src/forms/Dropdown.component.js
+++ b/src/forms/Dropdown.component.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import SelectField from "material-ui/SelectField/SelectField";
 import TextField from "material-ui/TextField";

--- a/src/forms/GreyFieldsTable.component.js
+++ b/src/forms/GreyFieldsTable.component.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import DropDown from "../forms/form-fields/drop-down";
 import LinearProgress from "material-ui/LinearProgress/LinearProgress";

--- a/src/forms/RichDropdown.component.js
+++ b/src/forms/RichDropdown.component.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import _ from "lodash";
 import TextField from "material-ui/TextField";

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -1,5 +1,4 @@
 import React from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import SelectField from "material-ui/SelectField/SelectField";
 import TextField from "material-ui/TextField";

--- a/src/forms/form-fields/icon-picker.js
+++ b/src/forms/form-fields/icon-picker.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import IconPicker from "d2-ui/lib/icon-picker/IconPicker.component";
 
 export default function IconPickerField(props) {

--- a/src/forms/form-fields/text-field.js
+++ b/src/forms/form-fields/text-field.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import createReactClass from 'create-react-class';
 import PropTypes from "prop-types";
 import TextField from "material-ui/TextField/TextField";
 import Action from "d2-ui/lib/action/Action";

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -2,7 +2,6 @@ import fp from "lodash/fp";
 import _ from "../utils/lodash-mixins";
 import { generateUid } from "d2/lib/uid";
 import moment from "moment";
-import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import {
     getCategoryCombos,
     collectionToArray,
@@ -20,6 +19,7 @@ import {
     sendMessageToGroups,
     getCategoryCombo,
     setAttributes,
+    getOwnedPropertyJSON,
 } from "../utils/Dhis2Helpers";
 
 import { getCoreCompetencies, getProject } from "./dataset";

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -145,6 +145,7 @@ class Factory {
                 .then(sharing =>
                     _(sharing.object.userGroupAccesses)
                         .map(getCode)
+                        .compact()
                         .uniq()
                         .value()
                 )

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -1,8 +1,7 @@
 import { generateUid } from "d2/lib/uid";
 import _ from "lodash";
-import { update, collectionToArray, subQuery } from "../utils/Dhis2Helpers";
+import { update, collectionToArray, subQuery, getOwnedPropertyJSON } from "../utils/Dhis2Helpers";
 import fp from "lodash/fp";
-import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import memoize from "nano-memoize";
 
 const toArray = collectionToArray;

--- a/src/models/data-periods.js
+++ b/src/models/data-periods.js
@@ -1,9 +1,8 @@
 import moment from "moment";
-import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import { generateUid } from "d2/lib/uid";
 
 import _ from "../utils/lodash-mixins";
-import { setAttributes, postMetadata, getCategoryCombos, mapPromise } from "../utils/Dhis2Helpers";
+import { setAttributes, postMetadata, getCategoryCombos, mapPromise, getOwnedPropertyJSON } from "../utils/Dhis2Helpers";
 import Settings from "./Settings";
 import DataSetStore from "./DataSetStore";
 

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -184,7 +184,18 @@ function getUserGroups(d2, names) {
 
 function getSharing(d2, object) {
     const api = d2.Api.getApi();
-    return api.get(`sharing?type=${object.modelDefinition.name}&id=${object.id}`);
+    const fields = [
+        "id",
+        "name",
+        "publicAccess",
+        "userAccesses",
+        "userGroupAccesses",
+        "externalAccess",
+    ].join(",");
+
+    return api
+        .get(`${object.modelDefinition.plural}/${object.id}?fields=${fields}`)
+        .then(object => ({ object }));
 }
 
 function getKey(s) {

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -1,5 +1,5 @@
+import { getJSONForProperties } from "d2/lib/model/helpers/json";
 import { generateUid } from "d2/lib/uid";
-import { getOwnedPropertyJSON } from "d2/lib/model/helpers/json";
 import _ from "./lodash-mixins";
 
 function collectionToArray(collectionOrArray) {
@@ -561,6 +561,17 @@ function getDseId(dse) {
         .join(".");
 }
 
+function getOwnedPropertyJSON(model) {
+    const ownedProperties = [
+        ...model.modelDefinition.getOwnedPropertyNames(),
+        "publicAccess",
+        "userAccesses",
+        "userGroupAccesses",
+    ]
+
+    return getJSONForProperties(model, ownedProperties);
+}
+
 export {
     getDseId,
     accesses,
@@ -594,4 +605,5 @@ export {
     subQuery,
     getCategoryCombo,
     setAttributes,
+    getOwnedPropertyJSON,
 };

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -192,14 +192,14 @@ function getKey(s) {
 }
 
 function buildSharingFromUserGroupNames(baseSharing, userGroups, userGroupSharingByName) {
-    const userGroupsByName = _.keyBy(userGroups, userGroup => getKey(userGroup.name))
+    const userGroupsByName = _.keyBy(userGroups, userGroup => getKey(userGroup.name));
     const userGroupAccesses = _(userGroupSharingByName)
         .map((sharing, name) => {
             const userGroup = userGroupsByName[getKey(name)];
             if (userGroup) {
-                return _.imerge(sharing, { id: userGroup.id })
+                return _.imerge(sharing, { id: userGroup.id });
             } else {
-                console.log(`User has no access to user group: ${name}`)
+                console.log(`User has no access to user group: ${name}`);
                 return null;
             }
         })
@@ -543,8 +543,11 @@ function setAttributes(initialAttributeValues, valuesByAttributeId) {
 }
 
 function getDseId(dse) {
-    const parts = [dse.dataSet, dse.dataElement, dse.categoryCombo]
-    return _(parts).compact().map(obj => obj.id).join(".");
+    const parts = [dse.dataSet, dse.dataElement, dse.categoryCombo];
+    return _(parts)
+        .compact()
+        .map(obj => obj.id)
+        .join(".");
 }
 
 export {

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -478,14 +478,14 @@ async function getFilteredDatasets(d2, config, page, sorting, filters) {
         );
         // Truncate IDs to avoid 413 URL too large
         const maxUids = (8192 - paramsSize - 1000) / (11 + 3);
-        const filters = [
+        const fullFilters = [
             ...baseFilters,
             `id:in:[${_(datasetsByApp)
                 .take(maxUids)
                 .map("id")
                 .join(",")}]`,
         ];
-        return model.list(cleanOptions({ order, fields, filter: filters, page }));
+        return model.list(cleanOptions({ order, fields, filter: fullFilters, page }));
     } else {
         return model.list(cleanOptions({ order, fields, filter: baseFilters, page }));
     }


### PR DESCRIPTION
Closes https://app.clickup.com/t/1mmpkjn

The most relevant changes refer to sharing, as all access fields (externalAccess, publicAccess, userAccesses, userGroupAccesses) have been grouped into a new `sharing` property. Old properties can still be used, but must be explicitly requested. 

That change was introduced in 2.36 (undocumented, or at least I've been unable to find any reference on the release notes). Compare:

https://play.dhis2.org/2.35.8/api/dataSets/lyLU2wR22tC.json?fields=:owner
https://play.dhis2.org/2.36.4/api/dataSets/lyLU2wR22tC.json?fields=:owner