### PR TITLE
Show change-end-date-for-year contextual actions only for admins

### DIFF
--- a/src/DataSets/context.actions.js
+++ b/src/DataSets/context.actions.js
@@ -97,7 +97,7 @@ const { contextActions, contextMenuIcons, isContextActionAllowed, actions } = se
         name: "end_date_for_year",
         multiple: true,
         icon: "timeline",
-        isActive: canUpdate,
+        isActive: (d2, datasets) => canUpdate(d2, datasets) && currentUserHasAdminRole(d2),
         onClick: (datasets, options) => endDateForYearStore.setState({ datasets, options }),
         options: _.range(currentYear - 1, currentYear + 2 + 1),
     },


### PR DESCRIPTION
Related to https://app.clickup.com/t/1u62b16

Action "Change output/outcome end date for year" only shows dates for specific years, a UI section accessible only to admins. So we need to hide the contextual action unless the current user is an admin.