### PR TITLE
Set sections codes to match with core competencies

### DIFF
--- a/src/DataSets/Forms/InitialConfig.component.js
+++ b/src/DataSets/Forms/InitialConfig.component.js
@@ -56,7 +56,7 @@ const InitialConfig = createReactClass({
     },
 
     _getCoreCompetencies() {
-        const fields = ["name", "displayName"];
+        const fields = ["name", "displayName", "code"];
         const degsId = this.props.config.dataElementGroupSetCoreCompetencyId;
         return this._getDataElementGroups(degsId, fields);
     },

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -99,7 +99,7 @@ class Factory {
     getDataset(id) {
         const fields = [
             "*,dataSetElements[*,categoryCombo[*,categories[id,displayName]],dataElement[*,categoryCombo[*]]]",
-            "sections[*,href],organisationUnits[*],dataEntryForm[id]",
+            "sections[*,code,href],organisationUnits[*],dataEntryForm[id]",
         ].join(",");
         return this.d2.models.dataSets.get(id, { fields });
     }

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -110,11 +110,11 @@ const validateCoreItemsSelectedForCurrentUser = (d2, config) => {
         errors: [String]
     }
 */
-export const getDataSetInfo = (d2, config, sections) => {
+export const getDataSetInfo = (d2, config, dataset, sections) => {
     const validateCoreSelected = validateCoreItemsSelectedForCurrentUser(d2, config);
 
     const d2Sections = _(sections)
-        .map(section => getD2Section(d2, section))
+        .map(section => getD2Section(d2, dataset, section))
         .map((d2s, index) => _.set(d2s, "sortOrder", index))
         .value();
     const dataElements = _(d2Sections)
@@ -215,6 +215,7 @@ export const processDatasetSections = (d2, config, dataset, stateSections) => {
     const { sections, dataSetElements, indicators, errors } = getDataSetInfo(
         d2,
         config,
+        dataset,
         _.values(stateSections)
     );
 
@@ -321,7 +322,7 @@ const updateSectionsFromD2Sections = (sections, d2Sections, initialCoreCompetenc
     return sections.map(updateSection);
 };
 
-const getD2Section = (d2, section) => {
+const getD2Section = (d2, dataset, section) => {
     const items = _(section.items)
         .values()
         .filter("selected")
@@ -340,9 +341,14 @@ const getD2Section = (d2, section) => {
         .map(ind => ({ id: ind.id, displayName: ind.displayName, name: ind.displayName }))
         .uniqBy("id")
         .value();
+    const sectionTypeCode = section.type.toUpperCase() + "S";
+
+    // On creation, a data set has no ID, use a random string (prefix used only to observe uniqueness)
+    const randomId = dataset.id || getRandomString();
 
     return d2.models.sections.create({
         name: section.name,
+        code: [randomId, sectionTypeCode, section.coreCompetency.code].join("_"),
         displayName: section.name,
         showRowTotals: section.showRowTotals,
         showColumnTotals: section.showColumnTotals,
@@ -651,3 +657,7 @@ const getIndicatorsByGroupName = (d2, coreCompetencies) => {
             .value()
     );
 };
+
+function getRandomString() {
+    return (new Date().getTime().toString() + Math.random()).replace(".", "");
+}

--- a/src/models/dataset.js
+++ b/src/models/dataset.js
@@ -1,15 +1,21 @@
 import _ from "lodash";
 
 export function getCoreCompetencies(d2, config, dataset) {
-    const extractCoreCompetenciesFromSection = section => {
-        const match = section.name.match(/^(.*) (Outputs|Outcomes)(@|$)/);
-        return match ? match[1] : null;
+    const extractCoreCompetenciesCodesFromSection = section => {
+        const { code } = section;
+        if (!code) {
+            console.error(`Section has not code: ${section.id}`);
+            return;
+        }
+        const [_prefix, _type, ...ccCodeParts] = section.code.split("_");
+        return ccCodeParts.join("_");
     };
 
-    const coreCompetencyNames = _(dataset.sections.toArray())
-        .map(extractCoreCompetenciesFromSection)
+    const coreCompetencyCodes = _(dataset.sections.toArray())
+        .map(extractCoreCompetenciesCodesFromSection)
         .compact()
-        .uniq();
+        .uniq()
+        .value();
 
     return d2.models.dataElementGroups
         .filter()
@@ -17,8 +23,8 @@ export function getCoreCompetencies(d2, config, dataset) {
         .equals(config.dataElementGroupSetCoreCompetencyId)
         .list({
             paging: false,
-            filter: `name:in:[${coreCompetencyNames.join(",")}]`,
-            fields: "id,name,displayName",
+            filter: `code:in:[${coreCompetencyCodes.join(",")}]`,
+            fields: "id,code,name,displayName",
         })
         .then(collection => collection.toArray());
 }

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,5 @@
+To run the scripts, copy and execute in a node/TS/d2-api project (i.e d2-tools):
+
+```
+$ npx ts-node src/scripts/name.ts ARGS
+```

--- a/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
+++ b/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
@@ -1,0 +1,149 @@
+import _ from "lodash";
+import { command, run } from "cmd-ts";
+import { getApiUrlOption, getD2Api } from "./common";
+import logger from "utils/log";
+import { promiseMap, runMetadata } from "data/dhis2-utils";
+import { D2Api, MetadataPick } from "types/d2-api";
+import { NamedRef } from "domain/entities/Base";
+import { Maybe } from "utils/ts-utils";
+
+export function runCli() {
+    const compareCmd = command({
+        name: "fix-sections-nrc-datasets",
+        description: "Fix NRC Data Set Configuration app sections after core competencies rename",
+        args: { url: getApiUrlOption({ long: "url" }) },
+        handler: async args => {
+            const api = getD2Api(args.url);
+            const repo = new DataSetD2Repository(api);
+            new FixSectionsAfterCoreCompetenciesRenameUseCase(repo).execute();
+        },
+    });
+
+    const args = process.argv.slice(2);
+    run(compareCmd, args);
+}
+
+runCli();
+
+class FixSectionsAfterCoreCompetenciesRenameUseCase {
+    constructor(private dataSetsRepository: DataSetD2Repository) {}
+
+    async execute() {
+        const coreCompetenciesMapping = new Map([
+            ["SHELTER", "SHELTER & SETTLEMENTS"],
+            ["FOOD SECURITY", "LIVELIHOODS & FOOD SECURITY"],
+            ["CAMP MANAGEMENT", "PROTECTION FROM VIOLENCE"],
+        ]);
+
+        await this.dataSetsRepository.fixSections(coreCompetenciesMapping);
+    }
+}
+
+class DataSetD2Repository {
+    createdByAppAttributeCode = "GL_CREATED_BY_DATASET_CONFIGURATION";
+
+    constructor(private api: D2Api) {}
+
+    async fixSections(coreCompetenciesMapping: Map<string, string>) {
+        const dataSets = await this.getDataSets();
+        const coreCompetenciesByName = await this.getCoreCompetencies();
+        const sections = _.flatMap(dataSets, dataSet => dataSet.sections);
+
+        const sectionsFixed = _(sections)
+            .map(section => this.fixSection(section, coreCompetenciesByName, coreCompetenciesMapping))
+            .compact()
+            .value();
+
+        logger.info(`Core competencies: ${_.keys(coreCompetenciesByName).join(", ")}`);
+        logger.info(`Data sets: ${dataSets.length} - Sections: ${sections.length}`);
+        logger.info(`Sections to fix: ${sectionsFixed.length}`);
+
+        this.saveSections(sectionsFixed);
+    }
+
+    private saveSections(sections: D2Section[]) {
+        if (_.isEmpty(sections)) return;
+        const sectionsGroupList = _.chunk(sections, 100);
+
+        return promiseMap(sectionsGroupList, async (sectionsChunk, idx) => {
+            logger.info(`POST ${sectionsChunk.length} sections: ${idx + 1}/${sectionsGroupList.length}`);
+            const res = await runMetadata(this.api.metadata.post({ sections: sectionsChunk }));
+            logger.info(`Result: ${res.status} (${JSON.stringify(res.stats)})`);
+        });
+    }
+
+    private fixSection(
+        section: D2Section,
+        coreCompetenciesByName: CoreCompetenciesIndexedByName,
+        coreCompetenciesRenameMapping: RenameMapping
+    ): Maybe<D2Section> {
+        const match = section.name.match(/^(.*) (Outputs|Outcomes)$/);
+        const err = `Cannot match section: id='${section.id}' name='${section.name}'`;
+        if (!match) throw new Error(err);
+        const [sectionName, type] = match.slice(1);
+        if (!sectionName || !type) throw new Error(err);
+
+        const ccName = coreCompetenciesRenameMapping.get(sectionName) || sectionName;
+        const coreCompetency = coreCompetenciesByName[ccName];
+        logger.debug(`section ${section.id} (${section.name}): sectionName=${sectionName}, type=${type}`);
+        if (!coreCompetency) throw new Error(`Core competency (DEGroup) not found: name='${ccName}'`);
+
+        const name = [coreCompetency.name, type].join(" ");
+        const code = [section.dataSet.id, type.toUpperCase(), coreCompetency.code].join("_");
+        const sectionFixed: D2Section = { ...section, name: name, code: code };
+        return _.isEqual(section, sectionFixed) ? undefined : sectionFixed;
+    }
+
+    private async getCoreCompetencies(): Promise<Record<Name, CoreCompetency>> {
+        const { dataElementGroupSets } = await this.api.metadata
+            .get({
+                dataElementGroupSets: {
+                    fields: {
+                        id: true,
+                        code: true,
+                        dataElementGroups: { id: true, code: true, name: true },
+                    },
+                    filter: { code: { eq: "GL_CoreComp_DEGROUPSET" } },
+                },
+            })
+            .getData();
+
+        const coreCompetencySet = dataElementGroupSets[0];
+        if (!coreCompetencySet) throw new Error("Cannot get dataElementGroupSet");
+
+        return _.keyBy(coreCompetencySet.dataElementGroups, deg => deg.name);
+    }
+
+    private async getDataSets(): Promise<D2DataSet[]> {
+        const { dataSets } = await this.api.metadata.get(metadataQuery).getData();
+
+        return dataSets.filter(dataSet =>
+            dataSet.attributeValues.some(
+                av => av.attribute.code === this.createdByAppAttributeCode && av.value === "true"
+            )
+        );
+    }
+}
+
+const metadataQuery = {
+    dataSets: {
+        fields: {
+            attributeValues: { value: true, attribute: { code: true } },
+            sections: { $owner: true },
+        },
+    },
+} as const;
+
+interface CoreCompetency extends NamedRef {
+    code: string;
+}
+
+type Name = string;
+
+type CoreCompetenciesIndexedByName = Record<Name, CoreCompetency>;
+
+type RenameMapping = Map<string, string>;
+
+type D2DataSet = MetadataPick<typeof metadataQuery>["dataSets"][number];
+
+type D2Section = D2DataSet["sections"][number];

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -457,7 +457,7 @@ async function getFilteredDatasets(d2, config, page, sorting, filters) {
     const fields =
         "id,name,displayName,displayDescription,shortName,created,lastUpdated,externalAccess," +
         "publicAccess,userAccesses,userGroupAccesses,user,access,attributeValues," +
-        "periodType,sections[id,name],dataInputPeriods~paging(1;1)";
+        "periodType,sections[id,code,name],dataInputPeriods~paging(1;1)";
     const cleanOptions = options =>
         _.omitBy(options, value => _.isArray(value) && _.isEmpty(value));
     const baseFilters = _.compact([searchValue ? `displayName:ilike:${searchValue}` : null]);


### PR DESCRIPTION
Closes https://app.clickup.com/t/865c48cuk

## Implementation 

- Until now, we matched sections (`dataSet.sections`) with core competencies (`dataElementGroup`) using the name. But this fail when the core competencies are renamed. Use `dataSet.sections[].code` to match with the groups. Code: `${dataSet.id}_OUTPUT|OUTCOME_${coreCompetency.code}`.

This script must be run to fix all the existing sections:

```
$ npx ts-node src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts --url="http://admin:district@localhost:8080"
````

## What to test?

1. Edit existing data set which was broken + check that core competencies are now selected  + add some new core competency + save + check if all metadata was persisted
1. Create a new dataset + save + check