### PR TITLE
Change default values for createdByApp + sendNotification

### DIFF
--- a/src/DataSets/DataSets.component.js
+++ b/src/DataSets/DataSets.component.js
@@ -119,7 +119,7 @@ const DataSets = createReactClass({
             logsPageLast: 0,
             logsOldestDate: null,
             sharing: null,
-            showOnlyCreatedByApp: true,
+            showOnlyCreatedByApp: false,
         };
     },
 

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -122,7 +122,7 @@ class Factory {
             periodType: "Monthly",
             dataInputPeriods: [],
             categoryCombo: { id: this.config.categoryComboId },
-            notifyCompletingUser: true,
+            notifyCompletingUser: false,
             noValueRequiresComment: false,
             legendSets: [],
             organisationUnits: [],


### PR DESCRIPTION
Closes https://app.clickup.com/t/865d6ft6f

- [x] Unset "only created by the app" checkbox on app start.
- [x] Widget -> New -> "send notification to completing user" set to false

To discuss: Do we need to create an script to change this second flag for existing data sets?