### PR TITLE
Use only country code (no core competency) for group sharings

### DIFF
--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -709,10 +709,9 @@ export default class DataSetStore {
         return update(categoryCombo, sharing.object);
     }
 
-    _getUserGroupName(coreCompetency, countryCode) {
-        // coreCompetency.name = "FOOD SECURITY" -> "${countryCode}_foodsecurityUsers"
-        const key = coreCompetency.name.toLocaleLowerCase().replace(/\W+/g, "");
-        return `${countryCode}_${key}Users`;
+    _getUserGroupName(_coreCompetency, countryCode) {
+        // https://app.clickup.com/t/865d6fte5 - Use only country code
+        return `${countryCode}_Users`;
     }
 
     _addWarnings(saving, msgs) {


### PR DESCRIPTION
Closes https://app.clickup.com/t/865d6fte5

- [x] Client: "CO_[CC]USER. It will just be CO_USER. ". Done: `CO_washUsers` -> `CO_Users`
- [ ] Client: "come across a problem in the sharing setting application when it comes to sharing settings" -> Client was asked to see that to do