### PR TITLE
[fix] Use name for categoryCombo/category/categoryOp…

### DIFF
--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -98,7 +98,7 @@ class Factory {
 
     getDataset(id) {
         const fields = [
-            "*,dataSetElements[*,categoryCombo[*,categories[id,displayName]],dataElement[*,categoryCombo[*]]]",
+            "*,dataSetElements[*,categoryCombo[*,categories[id,name,displayName]],dataElement[*,categoryCombo[*]]]",
             "sections[*,code,href],organisationUnits[*],dataEntryForm[id]",
         ].join(",");
         return this.d2.models.dataSets.get(id, { fields });

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -539,7 +539,7 @@ const filterDataElements = (dataElements, requiredDegIds) => {
 /* Return object {dataElementGroupId: dataElementGroupSetId} */
 const getDataElementGroupRelations = d2 => {
     return d2.models.dataElementGroupSets
-        .list({ fields: "id,displayName,dataElementGroups[id,displayName]" })
+        .list({ fields: "id,name,displayName,dataElementGroups[id,name,displayName]" })
         .then(collection =>
             toArray(collection).map(degSet =>
                 _(toArray(degSet.dataElementGroups))
@@ -601,11 +601,11 @@ const getDataElements = async (d2, dataElementFilters) => {
         "attributeValues[value,attribute[id]]",
     ];
 
-    const dataElementGroupsFields = "id,displayName";
+    const dataElementGroupsFields = "id,name,displayName";
 
     const categoryComboFields =
-        "id,displayName,categoryOptionCombos[id,displayName,categoryOptions[id,displayName]]," +
-        "categories[id,displayName,categoryOptions[id,displayName]]";
+        "id,name,displayName,categoryOptionCombos[id,name,displayName,categoryOptions[id,displayName]]," +
+        "categories[id,name,displayName,categoryOptions[id,name,displayName]]";
 
     const dataElements = await getFilteredItems(d2.models.dataElements, dataElementFilters, {
         fields: fields.join(","),

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -40,8 +40,8 @@ function redirectToLogin(baseUrl) {
 function getCategoryCombos(d2, { cocFields, filterIds } = {}) {
     return d2.models.categoryCombos.list({
         fields: _([
-            "id,displayName,dataDimensionType,isDefault",
-            "categories[id,displayName,categoryOptions[id,displayName]]",
+            "id,name,displayName,dataDimensionType,isDefault",
+            "categories[id,name,displayName,categoryOptions[id,name,displayName]]",
             cocFields ? `categoryOptionCombos[${cocFields}]` : null,
         ])
             .compact()
@@ -120,12 +120,12 @@ function getDisaggregationForCategories(d2, dataElement, categoryCombos, categor
         const categoryOptions = categories.map(c => toArray(c.categoryOptions));
         const categoryOptionCombos = _.cartesianProduct(...categoryOptions).map(cos => ({
             id: generateUid(),
-            name: cos.map(co => co.displayName).join(", "),
+            name: cos.map(co => co.name).join(", "),
             displayName: cos.map(co => co.displayName).join(", "),
             categoryCombo: { id: newCategoryComboId },
             categoryOptions: cos,
         }));
-        const ccName = allValidCategories.map(cc => cc.displayName).join("/");
+        const ccName = allValidCategories.map(cc => cc.name).join("/");
         const newCategoryCombo = d2.models.categoryCombo.create({
             id: newCategoryComboId,
             dataDimensionType: "DISAGGREGATION",


### PR DESCRIPTION
Required by https://app.clickup.com/t/865czeuaz

Notes:

- When creating new categoryCombos / categoryOptionCombos, we were using displayName. Use instead name, so the original name (English) and not the current translations is used.
- Regarding the existing category combos: the simplest approach is to change its name to English, so we don't change any relation using its ID.