### PR TITLE
[performance] Get only dataset category combos on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "2.4.0",
+    "version": "2.6.0",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -40,7 +40,7 @@ function redirectToLogin(baseUrl) {
 function getCategoryCombos(d2, { cocFields, filterIds } = {}) {
     return d2.models.categoryCombos.list({
         fields: _([
-            "id,name,displayName,dataDimensionType,isDefault",
+            "id,name,displayName,isDefault",
             "categories[id,name,displayName,categoryOptions[id,name,displayName]]",
             cocFields ? `categoryOptionCombos[${cocFields}]` : null,
         ])


### PR DESCRIPTION
Fixes https://app.clickup.com/t/862kh7896

- On save, category combos were retrieved with all their category option combos. That's a large response. Restrict the call to the category combos used in the data set being saved/created. The size is reduced drastically (example: 10.2k and 12 ms)
- Tested on edit and create.