### PR TITLE
[fix] Avoid duplicated category combos with user's locale

### DIFF
--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -100,11 +100,16 @@ function getDisaggregationForCategories(d2, dataElement, categoryCombos, categor
             ? allCategories.filter(category => categoriesById[category.id].name !== "default")
             : allCategories;
     const combinedCategoriesIds = getCategoryIds(allValidCategories);
-    const existingCategoryCombo = categoryCombos.find(cc =>
-        _(getCategoryIds(cc.categories))
-            .sortBy()
-            .isEqual(_.sortBy(combinedCategoriesIds))
-    );
+
+    // Get an existing categoryCombo (with the shortest name, if there are duplicates)
+    // with matching categories (in any order).
+    const existingCategoryCombo = _(categoryCombos)
+        .sortBy(categoryCombo => categoryCombo.name.length)
+        .find(categoryCombo =>
+            _(getCategoryIds(categoryCombo.categories))
+                .sortBy()
+                .isEqual(_.sortBy(combinedCategoriesIds))
+        );
     const cacheKey = combinedCategoriesIds.join(".");
     const cachedCategoryCombo = cachedCategoryCombos[cacheKey];
 

--- a/src/utils/Dhis2Helpers.js
+++ b/src/utils/Dhis2Helpers.js
@@ -97,9 +97,7 @@ function getDisaggregationForCategories(d2, dataElement, categoryCombos, categor
     // Special category <default> should be used only when no other category is present, remove otherwise
     const allValidCategories =
         allCategories.length > 1
-            ? allCategories.filter(
-                  category => categoriesById[category.id].displayName !== "default"
-              )
+            ? allCategories.filter(category => categoriesById[category.id].name !== "default")
             : allCategories;
     const combinedCategoriesIds = getCategoryIds(allValidCategories);
     const existingCategoryCombo = categoryCombos.find(cc =>


### PR DESCRIPTION
Closes https://app.clickup.com/t/8694g4ruf

- [ ] Problem: GL-E703/A: default -> defaillance+Sex -> FAIL. We were checking the default category with displayName==="default", use name ==="default" instead (code cannot be used, is not set).