### PR TITLE
Disable core items selection validation for all users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -83,22 +83,8 @@ const getCachedD2 = d2 => {
     }
 };
 
-const validateCoreItemsSelectedForCurrentUser = (d2, config) => {
-    // d2.currentUser does not expose the user group IDs, get them by introspection
-    const userGroupsSymbol = Object.getOwnPropertySymbols(d2.currentUser).find(
-        symbol => symbol.toString() === "Symbol(userGroups)"
-    );
-
-    if (!userGroupsSymbol || !d2.currentUser[userGroupsSymbol]) {
-        console.error("Cannot get user groups for current user");
-        return true;
-    } else if (!config.exclusionRuleCoreUserGroupId) {
-        console.error("Exclusion user group id not configured");
-        return true;
-    } else {
-        const userGroupIds = d2.currentUser[userGroupsSymbol];
-        return !_(userGroupIds).includes(config.exclusionRuleCoreUserGroupId);
-    }
+const validateCoreItemsSelectedForCurrentUser = (_d2, _config) => {
+    return false;
 };
 
 /* Return an object with the info of the sections and selected dataElements/indicators and errors:


### PR DESCRIPTION
Closes https://app.clickup.com/t/8695f1ubf

- [x] Core indicators, we had this validation: if the current user does not belong to group GL_AllAdmins, validate selection -> REMOVED
- [x] Donor and Local indicators: it's validated for all users. KEPT (the ticket is a bit ambiguous, it specifies "Mandatory Indicators" but also "select any indicator and proceed". To confirm with @adrianq 