### PR TITLE
Get current user roles using direct /api/me

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "2.6.3",
+    "version": "2.6.4",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {

--- a/src/models/DataSetStore.js
+++ b/src/models/DataSetStore.js
@@ -170,9 +170,10 @@ class Factory {
     }
 
     getUserRolesForCurrentUser() {
-        // Dhis2 has d2.currentUser.getUserRoles(), but the call generates a wrong URL and fails.
-        return this.d2.models.users
-            .get(this.d2.currentUser.id, { fields: "userCredentials[userRoles[id,name]]" })
+        // d2.currentUser.getUserRoles generates an invalid URL. Use directly endpoint /api/me instead.
+        const api = d2.Api.getApi();
+        return api
+            .get("/me", { fields: "userCredentials[userRoles[id,name]]" })
             .then(user => user.userCredentials.userRoles);
     }
 


### PR DESCRIPTION
Fixes https://app.clickup.com/t/8695f1yfq

Motivation: `d2.currentUser.getUserRoles` fails but the workaround uses `/api/users/ID`, an endpoint which has got extra protection on the last DHIS2 releases. So instead, let's call /api/me to get the user roles.

Tested: the user can edit existing data sets and create new ones.