### PR TITLE
[fix] Split getFilteredItems requests to avoid 414

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "d2-dataset-configuration",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "Dataset Configuration User Interface",
     "main": "src/index.html",
     "scripts": {


### PR DESCRIPTION
https://app.clickup.com/t/8697ycw08

Some dataElements requests were being terminated by the server (without error). But clearly it as a HTTP 414, as the URL is large. The size is 6.6K and it starts working when cut to 5.6K. Added the typical split to the filter function (300 ids, which should generate requests around 4K)

- [x] Deploy GORS PRO