### PR TITLE
check for undefined groupSet for indicators

### DIFF
--- a/src/data/D2ApiIndicator.ts
+++ b/src/data/D2ApiIndicator.ts
@@ -194,10 +194,10 @@ export class D2ApiIndicator {
                 if (!scope) return undefined;
 
                 const theme = indicator.indicatorGroups.find(
-                    ig => ig.indicatorGroupSet.id === config.indicatorGroupSets.theme.id
+                    ig => ig.indicatorGroupSet?.id === config.indicatorGroupSets.theme.id
                 );
                 const status = indicator.indicatorGroups.find(
-                    ig => ig.indicatorGroupSet.id === config.indicatorGroupSets.status.id
+                    ig => ig.indicatorGroupSet?.id === config.indicatorGroupSets.status.id
                 );
                 const group = indicator.attributeValues.find(
                     attribute => attribute.attribute.id === config.attributes.group.id
@@ -342,7 +342,7 @@ type D2IndicatorGroup = {
         indicatorGroups: Array<{
             displayName: string;
             id: Id;
-            indicatorGroupSet: { id: Id; displayName: string };
+            indicatorGroupSet?: { id: Id; displayName: string };
         }>;
         numerator: string;
     }>;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8698kxcwj

### :memo: Implementation

- [x] Check undefined values on indicators with no groupSet
- [x] Update dataStore settings. The key `dataSetPeriodDateAttribute` was missing.

### :video_camera: Screenshots/Screen capture

[Project-Configuration-app_loading_error.webm](https://github.com/user-attachments/assets/86b07f41-51b5-4b33-bbb6-c75d14787b2e)

### :fire: Notes to the tester

#8698kxcwj