### PR TITLE
replicate share settings from project to dataSet

### DIFF
--- a/src/data/D2ApiSharing.ts
+++ b/src/data/D2ApiSharing.ts
@@ -1,25 +1,13 @@
-import _ from "lodash";
 import { AccessData, AccessType } from "$/domain/entities/DataSet";
 import { Permission, Permissions } from "$/domain/entities/Permission";
+import { Id } from "$/domain/entities/Ref";
+import _ from "$/domain/entities/generic/Collection";
+import { HashMap } from "$/domain/entities/generic/HashMap";
 
 export class D2ApiSharing {
     buildPermission(permissions: string, permissionType: "data" | "metadata"): Permission {
-        switch (permissionType) {
-            case "metadata": {
-                const { canRead, canWrite } = this.buildPermissionByType(
-                    permissions,
-                    permissionType
-                );
-                return Permission.create({ read: canRead, write: canWrite });
-            }
-            case "data": {
-                const { canWrite, canRead } = this.buildPermissionByType(
-                    permissions,
-                    permissionType
-                );
-                return Permission.create({ read: canRead, write: canWrite });
-            }
-        }
+        const { canRead, canWrite } = this.buildPermissionByType(permissions, permissionType);
+        return Permission.create({ read: canRead, write: canWrite });
     }
 
     generateFullPermission(permissions: Permissions): OctalNotationPermission {
@@ -50,9 +38,8 @@ export class D2ApiSharing {
         ): D2AccessRecords => {
             return _(filteredAccess)
                 .filter(access => access.type === type)
-                .map(access => [access.id, this.generateD2PermissionFromAccess(access)])
-                .fromPairs()
-                .value();
+                .toHashMap(access => [access.id, this.generateD2PermissionFromAccess(access)])
+                .toObject();
         };
 
         return {
@@ -78,7 +65,7 @@ export class D2ApiSharing {
     }
 
     private buildAccessByType(accessData: D2AccessRecords, type: AccessType): AccessData[] {
-        const accessRecords = _(accessData).values().value();
+        const accessRecords = HashMap.fromObject(accessData).values();
         return accessRecords.map((access): AccessData => {
             return {
                 id: access.id,
@@ -107,16 +94,15 @@ export class D2ApiSharing {
 }
 
 export type D2ApiSharingFields = {
-    owner: string;
     external: boolean;
     users: D2AccessRecords;
     userGroups: D2AccessRecords;
     public: string;
 };
 
-type D2AccessRecords = Record<string, D2ApiSharingName>;
+type D2AccessRecords = Record<UserOrGroupId, D2ApiSharingName>;
 
-type D2ApiSharingName = {
+export type D2ApiSharingName = {
     displayName?: string;
     access: string;
     id: string;
@@ -127,6 +113,8 @@ type D2ApiSharingFieldsSave = {
     users: D2AccessRecords;
     userGroups: D2AccessRecords;
 };
+
+type UserOrGroupId = Id;
 
 // example: r------- // rw------
 export type OctalNotationPermission = string;

--- a/src/data/D2ApiSharing.ts
+++ b/src/data/D2ApiSharing.ts
@@ -43,16 +43,22 @@ export class D2ApiSharing {
         permissions: Permissions;
     }): D2ApiSharingFieldsSave {
         const { access, permissions } = options;
+
+        const convertToD2AccessRecords = (
+            filteredAccess: AccessData[],
+            type: AccessType
+        ): D2AccessRecords => {
+            return _(filteredAccess)
+                .filter(access => access.type === type)
+                .map(access => [access.id, this.generateD2PermissionFromAccess(access)])
+                .fromPairs()
+                .value();
+        };
+
         return {
-            publicAccess: this.generateFullPermission(permissions),
-            userAccesses: _(access)
-                .filter(access => access.type === "users")
-                .map(access => this.generateD2PermissionFromAccess(access))
-                .value(),
-            userGroupAccesses: _(access)
-                .filter(access => access.type === "groups")
-                .map(access => this.generateD2PermissionFromAccess(access))
-                .value(),
+            public: this.generateFullPermission(permissions),
+            users: convertToD2AccessRecords(access, "users"),
+            userGroups: convertToD2AccessRecords(access, "groups"),
         };
     }
 
@@ -117,9 +123,9 @@ type D2ApiSharingName = {
 };
 
 type D2ApiSharingFieldsSave = {
-    publicAccess: OctalNotationPermission;
-    userAccesses: D2ApiSharingName[];
-    userGroupAccesses: D2ApiSharingName[];
+    public: OctalNotationPermission;
+    users: D2AccessRecords;
+    userGroups: D2AccessRecords;
 };
 
 // example: r------- // rw------

--- a/src/data/D2ApiSharing.ts
+++ b/src/data/D2ApiSharing.ts
@@ -1,0 +1,126 @@
+import _ from "lodash";
+import { AccessData, AccessType } from "$/domain/entities/DataSet";
+import { Permission, Permissions } from "$/domain/entities/Permission";
+
+export class D2ApiSharing {
+    buildPermission(permissions: string, permissionType: "data" | "metadata"): Permission {
+        switch (permissionType) {
+            case "metadata": {
+                const { canRead, canWrite } = this.buildPermissionByType(
+                    permissions,
+                    permissionType
+                );
+                return Permission.create({ read: canRead, write: canWrite });
+            }
+            case "data": {
+                const { canWrite, canRead } = this.buildPermissionByType(
+                    permissions,
+                    permissionType
+                );
+                return Permission.create({ read: canRead, write: canWrite });
+            }
+        }
+    }
+
+    generateFullPermission(permissions: Permissions): OctalNotationPermission {
+        return [
+            this.convertPermissionToOctal(permissions.metadata),
+            this.convertPermissionToOctal(permissions.data),
+            "----",
+        ].join("");
+    }
+
+    generateD2PermissionFromAccess(accessData: AccessData): D2ApiSharingName {
+        return {
+            access: this.generateFullPermission(accessData.permissions),
+            id: accessData.id,
+            displayName: accessData.name,
+        };
+    }
+
+    generateSharingData(options: {
+        access: AccessData[];
+        permissions: Permissions;
+    }): D2ApiSharingFieldsSave {
+        const { access, permissions } = options;
+        return {
+            publicAccess: this.generateFullPermission(permissions),
+            userAccesses: _(access)
+                .filter(access => access.type === "users")
+                .map(access => this.generateD2PermissionFromAccess(access))
+                .value(),
+            userGroupAccesses: _(access)
+                .filter(access => access.type === "groups")
+                .map(access => this.generateD2PermissionFromAccess(access))
+                .value(),
+        };
+    }
+
+    mapSharingToEntity(sharing: D2ApiSharingFields): {
+        access: AccessData[];
+        permissions: Permissions;
+    } {
+        const users = this.buildAccessByType(sharing.users, "users");
+        const groups = this.buildAccessByType(sharing.userGroups, "groups");
+
+        const permissions = {
+            data: this.buildPermission(sharing.public, "data"),
+            metadata: this.buildPermission(sharing.public, "metadata"),
+        };
+
+        return { access: users.concat(groups), permissions };
+    }
+
+    private buildAccessByType(accessData: D2AccessRecords, type: AccessType): AccessData[] {
+        const accessRecords = _(accessData).values().value();
+        return accessRecords.map((access): AccessData => {
+            return {
+                id: access.id,
+                name: access.displayName ?? "",
+                permissions: {
+                    data: this.buildPermission(access.access, "data"),
+                    metadata: this.buildPermission(access.access, "metadata"),
+                },
+                type,
+            };
+        });
+    }
+
+    private convertPermissionToOctal(permission: Permission): OctalNotationPermission {
+        return permission.noAccess()
+            ? "--"
+            : [permission.read ? "r" : "-", permission.write ? "w" : "-"].join("");
+    }
+
+    private buildPermissionByType(permissions: string, permissionType: "data" | "metadata") {
+        const initialIndex = permissionType === "metadata" ? 0 : 2;
+        const canRead = permissions[initialIndex] === "r";
+        const canWrite = permissions[initialIndex + 1] === "w";
+        return { canRead, canWrite };
+    }
+}
+
+export type D2ApiSharingFields = {
+    owner: string;
+    external: boolean;
+    users: D2AccessRecords;
+    userGroups: D2AccessRecords;
+    public: string;
+};
+
+type D2AccessRecords = Record<string, D2ApiSharingName>;
+
+type D2ApiSharingName = {
+    displayName?: string;
+    access: string;
+    id: string;
+};
+
+type D2ApiSharingFieldsSave = {
+    publicAccess: OctalNotationPermission;
+    userAccesses: D2ApiSharingName[];
+    userGroupAccesses: D2ApiSharingName[];
+};
+
+// example: r------- // rw------
+export type OctalNotationPermission = string;

--- a/src/data/repositories/ConfigD2Repository.ts
+++ b/src/data/repositories/ConfigD2Repository.ts
@@ -4,7 +4,6 @@ import { D2ApiConfig, D2Config } from "$/data/repositories/D2ApiMetadata";
 import { convertToCategories } from "$/data/utils";
 import { CategoryCombination } from "$/domain/entities/CategoryCombination";
 import { Config } from "$/domain/entities/Config";
-import { Project } from "$/domain/entities/Project";
 import { Region, extractRegionCode } from "$/domain/entities/Region";
 import { Future, FutureData } from "$/domain/entities/generic/Future";
 import { ConfigRepository } from "$/domain/repositories/ConfigRepository";
@@ -112,12 +111,18 @@ export class ConfigD2Repository implements ConfigRepository {
                 paging: false,
             })
         ).map(d2Response => {
-            return d2Response.objects.map(region => ({
-                id: region.id,
-                name: region.name,
-                // org. unit code includes the region code in the first two letters before the underscore
-                code: Project.extractCode(region.code),
-            }));
+            return _(d2Response.objects)
+                .compactMap(region => {
+                    const regionCode = extractRegionCode(region.code);
+                    if (!regionCode) {
+                        console.warn(
+                            `Region ${region.name} (${region.id}) does not have a valid region code`
+                        );
+                        return undefined;
+                    }
+                    return { ...region, code: regionCode };
+                })
+                .value();
         });
     }
 

--- a/src/data/repositories/D2ApiCategoryOption.ts
+++ b/src/data/repositories/D2ApiCategoryOption.ts
@@ -5,6 +5,7 @@ import _ from "$/domain/entities/generic/Collection";
 import { chunkRequest } from "$/data/utils";
 import { FutureData } from "$/domain/entities/generic/Future";
 import { Maybe } from "$/utils/ts-utils";
+import { D2ApiSharingFields } from "$/data/D2ApiSharing";
 
 export class D2ApiCategoryOption {
     constructor(private api: D2Api) {}
@@ -14,7 +15,13 @@ export class D2ApiCategoryOption {
             return apiToFuture(
                 this.api.models.categoryOptions.get({
                     filter: { id: { in: categoryOptionsIds } },
-                    fields: { id: true, code: true, displayName: true, lastUpdated: true },
+                    fields: {
+                        id: true,
+                        code: true,
+                        displayName: true,
+                        lastUpdated: true,
+                        sharing: true,
+                    },
                     paging: false,
                 })
             ).map(response => response.objects);
@@ -27,7 +34,9 @@ export type D2CategoryOptionType = {
     id: string;
     displayName: string;
     lastUpdated: ISODateString;
+    sharing: D2ApiSharingFields;
 };
+
 export type D2CategoryOptionDates = {
     startDate: Maybe<ISODateString>;
     endDate: Maybe<ISODateString>;

--- a/src/data/repositories/DataSetD2Api.ts
+++ b/src/data/repositories/DataSetD2Api.ts
@@ -1,19 +1,11 @@
 import { D2Api, MetadataPick } from "$/types/d2-api";
 import { apiToFuture } from "$/data/api-futures";
-import {
-    AccessData,
-    AccessType,
-    CoreCompetency,
-    DataSet,
-    DisabledField,
-    OrgUnit,
-} from "$/domain/entities/DataSet";
+import { CoreCompetency, DataSet, DisabledField, OrgUnit } from "$/domain/entities/DataSet";
 import { Paginated } from "$/domain/entities/Paginated";
 import { GetDataSetOptions } from "$/domain/repositories/DataSetRepository";
 import { Future, FutureData } from "$/domain/entities/generic/Future";
 import { Maybe } from "$/utils/ts-utils";
 import { Id } from "$/domain/entities/Ref";
-import { Permission, Permissions } from "$/domain/entities/Permission";
 import _ from "$/domain/entities/generic/Collection";
 import { Project } from "$/domain/entities/Project";
 import { D2ApiCategoryOption } from "$/data/repositories/D2ApiCategoryOption";
@@ -27,14 +19,17 @@ import { DatePeriod } from "$/domain/entities/DatePeriod";
 import { DataSetList } from "$/domain/entities/DataSetList";
 import { COMMENT_SUFIX } from "$/domain/entities/DataElement";
 import { getStartEndDate, parsePeriodDateAttribute } from "$/data/period-dates";
+import { D2ApiSharing } from "$/data/D2ApiSharing";
 
 export class DataSetD2Api {
     private d2ApiCategoryOption: D2ApiCategoryOption;
     private d2ApiConfig: D2ApiConfig;
+    private d2ApiSharing: D2ApiSharing;
 
     constructor(private api: D2Api, private config: Config) {
         this.d2ApiCategoryOption = new D2ApiCategoryOption(this.api);
         this.d2ApiConfig = new D2ApiConfig(this.api);
+        this.d2ApiSharing = new D2ApiSharing();
     }
 
     getList(options: GetDataSetOptions): FutureData<Paginated<DataSetList>> {
@@ -66,8 +61,14 @@ export class DataSetD2Api {
                         name: d2DataSet.displayName,
                         lastUpdated: d2DataSet.lastUpdated,
                         permissions: {
-                            data: this.buildPermission(d2DataSet.sharing.public, "data"),
-                            metadata: this.buildPermission(d2DataSet.sharing.public, "metadata"),
+                            data: this.d2ApiSharing.buildPermission(
+                                d2DataSet.sharing.public,
+                                "data"
+                            ),
+                            metadata: this.d2ApiSharing.buildPermission(
+                                d2DataSet.sharing.public,
+                                "metadata"
+                            ),
                         },
                     });
                 });
@@ -158,6 +159,7 @@ export class DataSetD2Api {
     getProjectsByIds(ids: Id[]): FutureData<Project[]> {
         return this.d2ApiCategoryOption.getByIds(ids).map(categoryOptions => {
             return categoryOptions.map(categoryOption => {
+                const { access } = this.d2ApiSharing.mapSharingToEntity(categoryOption.sharing);
                 return Project.create({
                     id: categoryOption.id,
                     dataSets: [],
@@ -166,6 +168,7 @@ export class DataSetD2Api {
                     isOpen: false,
                     orgsUnits: [],
                     code: categoryOption.code,
+                    access: access,
                 });
             });
         });
@@ -238,6 +241,8 @@ export class DataSetD2Api {
             });
         });
 
+        const { access, permissions } = this.d2ApiSharing.mapSharingToEntity(d2DataSet.sharing);
+
         return DataSet.create({
             canBeUpdated: d2DataSet.access.update,
             periodDate: this.buildPeriodDateFromAttributes(d2DataSet, attributes),
@@ -258,13 +263,8 @@ export class DataSetD2Api {
             name: d2DataSet.displayName,
             shortName: d2DataSet.displayShortName,
             lastUpdated: d2DataSet.lastUpdated,
-            permissions: {
-                data: this.buildPermission(d2DataSet.sharing.public, "data"),
-                metadata: this.buildPermission(d2DataSet.sharing.public, "metadata"),
-            },
-            access: this.buildAccessByType(d2DataSet.userAccesses, "users").concat(
-                this.buildAccessByType(d2DataSet.userGroupAccesses, "groups")
-            ),
+            permissions: permissions,
+            access: access,
             coreCompetencies: _(dataElementGroups)
                 .compactMap(degCode => coreCompetencies.find(cc => cc.code === degCode))
                 .value(),
@@ -304,23 +304,6 @@ export class DataSetD2Api {
         return outputsIndicators.concat(outcomesIndicators);
     }
 
-    private buildAccessByType(
-        accessData: Array<{ id: Id; displayName: string; access: OctalNotationPermission }>,
-        type: AccessType
-    ): AccessData[] {
-        return accessData.map((access): AccessData => {
-            return {
-                id: access.id,
-                name: access.displayName,
-                permissions: {
-                    data: this.buildPermission(access.access, "data"),
-                    metadata: this.buildPermission(access.access, "metadata"),
-                },
-                type,
-            };
-        });
-    }
-
     private extractCompetencyCode(sectionId: Id, sectionCode: string): Maybe<string> {
         if (!sectionCode) {
             console.error(`Section has not code: ${sectionId}`);
@@ -328,46 +311,6 @@ export class DataSetD2Api {
         }
         const [_prefix, _type, ...ccCodeParts] = sectionCode.split("_");
         return ccCodeParts.join("_");
-    }
-
-    buildPermission(permissions: string, permissionType: "data" | "metadata"): Permission {
-        switch (permissionType) {
-            case "metadata": {
-                const { canRead, canWrite } = this.buildPermissionByType(
-                    permissions,
-                    permissionType
-                );
-                return Permission.create({ read: canRead, write: canWrite });
-            }
-            case "data": {
-                const { canWrite, canRead } = this.buildPermissionByType(
-                    permissions,
-                    permissionType
-                );
-                return Permission.create({ read: canRead, write: canWrite });
-            }
-        }
-    }
-
-    private buildPermissionByType(permissions: string, permissionType: "data" | "metadata") {
-        const initialIndex = permissionType === "metadata" ? 0 : 2;
-        const canRead = permissions[initialIndex] === "r";
-        const canWrite = permissions[initialIndex + 1] === "w";
-        return { canRead, canWrite };
-    }
-
-    private convertPermissionToOctal(permission: Permission): OctalNotationPermission {
-        return permission.noAccess()
-            ? "--"
-            : [permission.read ? "r" : "-", permission.write ? "w" : "-"].join("");
-    }
-
-    generateFullPermission(permissions: Permissions): OctalNotationPermission {
-        return [
-            this.convertPermissionToOctal(permissions.metadata),
-            this.convertPermissionToOctal(permissions.data),
-            "----",
-        ].join("");
     }
 
     private buildOutputsIndicators(d2DataSet: D2DataSet) {
@@ -494,7 +437,7 @@ export const dataSetFields = {
     notifyCompletingUser: true,
     id: true,
     lastUpdated: true,
-    sharing: { public: true },
+    sharing: true,
     displayShortName: true,
     sections: {
         id: true,
@@ -506,8 +449,6 @@ export const dataSetFields = {
             categoryOptionCombo: true,
         },
     },
-    userGroupAccesses: { id: true, displayName: true, access: true },
-    userAccesses: { id: true, displayName: true, access: true },
     attributeValues: { value: true, attribute: { id: true } },
     indicators: { id: true, numerator: true, denominator: true, code: true },
     dataSetElements: {
@@ -533,4 +474,3 @@ type D2DataSetFields = MetadataPick<{
 }>["dataSets"][number];
 
 type D2DataSet = { organisationUnits?: D2OrgUnit[] } & D2DataSetFields;
-export type OctalNotationPermission = string;

--- a/src/data/repositories/DataSetD2Repository.ts
+++ b/src/data/repositories/DataSetD2Repository.ts
@@ -26,6 +26,7 @@ import { DataSetToSave } from "$/domain/entities/DataSetToSave";
 import { Config } from "$/domain/entities/Config";
 import { DataSetList } from "$/domain/entities/DataSetList";
 import isEqual from "lodash/isEqual";
+import { D2ApiSharing } from "$/data/D2ApiSharing";
 
 const DIMENSITON_TYPE = "DISAGGREGATION" as const;
 const CUSTOM_FORM_STYLE = "NORMAL" as const;
@@ -33,10 +34,12 @@ const CUSTOM_FORM_STYLE = "NORMAL" as const;
 export class DataSetD2Repository implements DataSetRepository {
     private d2DataSetApi: DataSetD2Api;
     private D2ApiCategoryCombo: D2ApiCategoryCombo;
+    private d2ApiSharing: D2ApiSharing;
 
     constructor(private api: D2Api, private config: Config) {
         this.d2DataSetApi = new DataSetD2Api(this.api, this.config);
         this.D2ApiCategoryCombo = new D2ApiCategoryCombo(this.api);
+        this.d2ApiSharing = new D2ApiSharing();
     }
 
     getByName(name: string): FutureData<DataSetName[]> {
@@ -657,6 +660,7 @@ export class DataSetD2Repository implements DataSetRepository {
         existingAttributes: Maybe<D2AttributeValue[]>,
         config: D2Config
     ) {
+        const sharingData = this.d2ApiSharing.generateSharingData(dataSet);
         return {
             renderAsTabs: true,
             dataElementDecoration: true,
@@ -668,32 +672,15 @@ export class DataSetD2Repository implements DataSetRepository {
             name: dataSet.name,
             periodType: "Monthly",
             description: dataSet.description,
-            publicAccess: this.d2DataSetApi.generateFullPermission(dataSet.permissions),
+            publicAccess: sharingData.publicAccess,
             dataSetElements: this.buildDataSetElements(dataSet),
             indicators: _(dataSet.indicators)
                 .filter(indicator => indicator.type === "outcomes")
                 .map(indicator => ({ id: indicator.id }))
                 .uniqBy(indicator => indicator.id)
                 .value(),
-            userAccesses: dataSet.access
-                .filter(access => access.type === "users")
-                .map(access => {
-                    return {
-                        access: this.d2DataSetApi.generateFullPermission(access.permissions),
-                        id: access.id,
-                        displayName: access.name,
-                    };
-                }),
-            userGroupAccesses: _(dataSet.access)
-                .filter(access => access.type === "groups")
-                .map(groupAccess => {
-                    return {
-                        access: this.d2DataSetApi.generateFullPermission(groupAccess.permissions),
-                        id: groupAccess.id,
-                        displayName: groupAccess.name,
-                    };
-                })
-                .value(),
+            userAccesses: sharingData.userAccesses,
+            userGroupAccesses: sharingData.userGroupAccesses,
             organisationUnits: dataSet.orgUnits.map(ou => ({ id: ou.id })),
             attributeValues: this.buildD2Attributes(existingAttributes, dataSet, config.attributes),
             notifyCompletingUser: dataSet.notifyUser,

--- a/src/data/repositories/DataSetD2Repository.ts
+++ b/src/data/repositories/DataSetD2Repository.ts
@@ -317,10 +317,15 @@ export class DataSetD2Repository implements DataSetRepository {
             }
 
             const existingAttributes = existingDataSet?.attributeValues;
+            const sharingData = this.d2ApiSharing.generateSharingData(dataSet);
 
             const result = {
                 ...(existingDataSet || {}),
                 ...this.buildD2DataSet(dataSet, existingAttributes, config),
+                sharing: {
+                    ...(existingDataSet?.sharing || {}),
+                    ...sharingData,
+                },
             };
 
             const existingDataSetSections = existingSections.filter(
@@ -335,8 +340,7 @@ export class DataSetD2Repository implements DataSetRepository {
                 existingDataSetSections
             );
 
-            const { sharing: _, ...rest } = result;
-            return { ...rest, dataEntryForm: customForm };
+            return { ...result, dataEntryForm: customForm };
         });
     }
 
@@ -660,7 +664,6 @@ export class DataSetD2Repository implements DataSetRepository {
         existingAttributes: Maybe<D2AttributeValue[]>,
         config: D2Config
     ) {
-        const sharingData = this.d2ApiSharing.generateSharingData(dataSet);
         return {
             renderAsTabs: true,
             dataElementDecoration: true,
@@ -672,15 +675,12 @@ export class DataSetD2Repository implements DataSetRepository {
             name: dataSet.name,
             periodType: "Monthly",
             description: dataSet.description,
-            publicAccess: sharingData.publicAccess,
             dataSetElements: this.buildDataSetElements(dataSet),
             indicators: _(dataSet.indicators)
                 .filter(indicator => indicator.type === "outcomes")
                 .map(indicator => ({ id: indicator.id }))
                 .uniqBy(indicator => indicator.id)
                 .value(),
-            userAccesses: sharingData.userAccesses,
-            userGroupAccesses: sharingData.userGroupAccesses,
             organisationUnits: dataSet.orgUnits.map(ou => ({ id: ou.id })),
             attributeValues: this.buildD2Attributes(existingAttributes, dataSet, config.attributes),
             notifyCompletingUser: dataSet.notifyUser,

--- a/src/data/repositories/DataSetD2Repository.ts
+++ b/src/data/repositories/DataSetD2Repository.ts
@@ -26,7 +26,7 @@ import { DataSetToSave } from "$/domain/entities/DataSetToSave";
 import { Config } from "$/domain/entities/Config";
 import { DataSetList } from "$/domain/entities/DataSetList";
 import isEqual from "lodash/isEqual";
-import { D2ApiSharing } from "$/data/D2ApiSharing";
+import { D2ApiSharing, D2ApiSharingName } from "$/data/D2ApiSharing";
 
 const DIMENSITON_TYPE = "DISAGGREGATION" as const;
 const CUSTOM_FORM_STYLE = "NORMAL" as const;
@@ -319,7 +319,7 @@ export class DataSetD2Repository implements DataSetRepository {
             const existingAttributes = existingDataSet?.attributeValues;
             const sharingData = this.d2ApiSharing.generateSharingData(dataSet);
 
-            const result = {
+            const d2DataSet: D2DataSetToSave = {
                 ...(existingDataSet || {}),
                 ...this.buildD2DataSet(dataSet, existingAttributes, config),
                 sharing: {
@@ -333,14 +333,14 @@ export class DataSetD2Repository implements DataSetRepository {
             );
 
             const customForm = this.buildDataEntryForm(
-                result,
+                d2DataSet,
                 dataSet,
                 ccByDataSet,
                 config,
                 existingDataSetSections
             );
 
-            return { ...result, dataEntryForm: customForm };
+            return { ...d2DataSet, dataEntryForm: customForm };
         });
     }
 
@@ -833,3 +833,33 @@ export type D2SectionWithGreyFields = Omit<D2Section, "greyedFields"> & {
 };
 
 type D2Attribute = { attribute: { id: Id }; value: string };
+
+type D2DataSetToSave = {
+    renderAsTabs: boolean;
+    dataElementDecoration: boolean;
+    categoryCombo: Ref;
+    id: Id;
+    shortName: string;
+    name: string;
+    periodType: string;
+    description: string;
+    dataSetElements: Array<{
+        dataSet: Ref;
+        dataElement: Ref;
+        categoryCombo: { id: Maybe<Id> };
+    }>;
+    indicators: Ref[];
+    organisationUnits: Ref[];
+    attributeValues: Array<{
+        attribute: Ref;
+        value: Maybe<string>;
+    }>;
+    notifyCompletingUser: boolean;
+    openFuturePeriods: number;
+    expiryDays: number;
+    sharing: {
+        public: string;
+        users: Record<Id, D2ApiSharingName>;
+        userGroups: Record<Id, D2ApiSharingName>;
+    };
+};

--- a/src/data/repositories/ProjectD2Repository.ts
+++ b/src/data/repositories/ProjectD2Repository.ts
@@ -18,14 +18,17 @@ import { Maybe } from "$/utils/ts-utils";
 import { Config } from "$/domain/entities/Config";
 import { Stats } from "$/domain/entities/Stats";
 import { getErrorFromResponse } from "$/data/utils";
+import { D2ApiSharing } from "$/data/D2ApiSharing";
 
 export class ProjectD2Repository implements ProjectRepository {
     private d2DataSetApi: DataSetD2Api;
     private d2ApiConfig: D2ApiConfig;
+    private d2ApiSharing: D2ApiSharing;
 
     constructor(private api: D2Api, private config: Config) {
         this.d2DataSetApi = new DataSetD2Api(this.api, this.config);
         this.d2ApiConfig = new D2ApiConfig(this.api);
+        this.d2ApiSharing = new D2ApiSharing();
     }
 
     getById(id: Id): FutureData<Project> {
@@ -37,6 +40,7 @@ export class ProjectD2Repository implements ProjectRepository {
                     displayName: true,
                     lastUpdated: true,
                     organisationUnits: { id: true, code: true, path: true, displayName: true },
+                    sharing: true,
                 },
                 filter: { id: { eq: id } },
                 paging: false,
@@ -109,6 +113,7 @@ export class ProjectD2Repository implements ProjectRepository {
                     endDate: true,
                     lastUpdated: true,
                     organisationUnits: { id: true, code: true, displayName: true, path: true },
+                    sharing: true,
                 },
                 filter: { "categories.code": { eq: code }, ...this.buildDateFilter(options) },
                 order: "displayName:asc",
@@ -131,6 +136,7 @@ export class ProjectD2Repository implements ProjectRepository {
 
     private getProjectsWithDates(categoryOptions: D2CategoryOptionWithDates[]): Project[] {
         return categoryOptions.map(d2CategoryOption => {
+            const { access } = this.d2ApiSharing.mapSharingToEntity(d2CategoryOption.sharing);
             return Project.build({
                 dataSets: [],
                 code: d2CategoryOption.code,
@@ -144,6 +150,7 @@ export class ProjectD2Repository implements ProjectRepository {
                     name: orgUnit.displayName,
                     path: orgUnit.path.split("/").slice(1),
                 })),
+                access,
             });
         });
     }
@@ -197,6 +204,7 @@ export class ProjectD2Repository implements ProjectRepository {
                         displayName: true,
                         lastUpdated: true,
                         organisationUnits: { id: true, code: true, path: true, displayName: true },
+                        sharing: true,
                     },
                     order: this.buildOrderParam(options),
                 })
@@ -246,7 +254,9 @@ export class ProjectD2Repository implements ProjectRepository {
     private buildProject(
         d2CategoryOption: D2CategoryOptionType & { organisationUnits: D2OrgUnit[] }
     ): Project {
+        const { access } = this.d2ApiSharing.mapSharingToEntity(d2CategoryOption.sharing);
         return Project.build({
+            access: access,
             code: d2CategoryOption.code,
             id: d2CategoryOption.id,
             name: d2CategoryOption.displayName,

--- a/src/domain/entities/DataSet.ts
+++ b/src/domain/entities/DataSet.ts
@@ -214,10 +214,14 @@ export class DataSet extends Struct<DataSetAttrs>() {
 
     private getAccessFromProject(project: Maybe<Project>, config: Config): AccessData[] {
         if (!project || !project.code) return [];
-        const regionCode = extractRegionCode(project.code);
 
-        const region = config.regions.find(region => region.code === regionCode);
-        const userGroups = config.userGroups.filter(userGroup => userGroup.code === region?.code);
+        const regionCodes = config.regions
+            .filter(region => project.uniqueAccessCodes.includes(region.code))
+            .map(region => region.code);
+
+        const userGroups = config.userGroups.filter(userGroup =>
+            regionCodes.includes(userGroup.code)
+        );
 
         return this.buildAccessGroups(userGroups);
     }

--- a/src/domain/entities/Permission.ts
+++ b/src/domain/entities/Permission.ts
@@ -21,7 +21,7 @@ export class Permission extends Struct<PermissionAttrs>() {
         };
     }
 
-    static initialPermissions(): Permissions {
+    static noPermissions(): Permissions {
         return {
             data: Permission.create({ read: false, write: false }),
             metadata: Permission.create({ read: false, write: false }),

--- a/src/domain/entities/Permission.ts
+++ b/src/domain/entities/Permission.ts
@@ -20,6 +20,13 @@ export class Permission extends Struct<PermissionAttrs>() {
                 : Permission.create({ read: true, write: false }),
         };
     }
+
+    static initialPermissions(): Permissions {
+        return {
+            data: Permission.create({ read: false, write: false }),
+            metadata: Permission.create({ read: false, write: false }),
+        };
+    }
 }
 
 export type Permissions = { data: Permission; metadata: Permission };

--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -17,11 +17,10 @@ export type ProjectAttrs = {
 };
 
 export class Project extends Struct<ProjectAttrs>() {
-    get uniqueAccessCodes() {
+    get uniqueAccessCodes(): string[] {
         return _(this.access)
             .filter(access => access.type === "groups")
-            .map(access => Project.extractCode(access.name))
-            .filter(accessCode => accessCode.length > 0)
+            .compactMap(access => Project.extractCode(access.name))
             .uniq()
             .value();
     }
@@ -55,7 +54,7 @@ export class Project extends Struct<ProjectAttrs>() {
      * Output: "US"
      *
      */
-    static extractCode(value: string): string {
+    static extractCode(value: string): Maybe<string> {
         return (value.split("_")[0] || "").toUpperCase();
     }
 }

--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -1,8 +1,9 @@
-import { DataSet, OrgUnit } from "$/domain/entities/DataSet";
+import { AccessData, DataSet, OrgUnit } from "$/domain/entities/DataSet";
 import { ISODateString, Id } from "$/domain/entities/Ref";
 import { Struct } from "$/domain/entities/generic/Struct";
 import i18n from "$/utils/i18n";
 import { Maybe } from "$/utils/ts-utils";
+import _ from "$/domain/entities/generic/Collection";
 
 export type ProjectAttrs = {
     id: Id;
@@ -12,9 +13,19 @@ export type ProjectAttrs = {
     dataSets: DataSet[];
     lastUpdated: ISODateString;
     orgsUnits: OrgUnit[];
+    access: AccessData[];
 };
 
 export class Project extends Struct<ProjectAttrs>() {
+    get uniqueAccessCodes() {
+        return _(this.access)
+            .filter(access => access.type === "groups")
+            .map(access => Project.extractCode(access.name))
+            .filter(accessCode => accessCode.length > 0)
+            .uniq()
+            .value();
+    }
+
     static build(data: ProjectAttrs): Project {
         if (!data.id) {
             throw new Error(i18n.t("Project id is required"));

--- a/src/domain/entities/__tests__/DataSet.spec.ts
+++ b/src/domain/entities/__tests__/DataSet.spec.ts
@@ -19,13 +19,13 @@ const projectTest: Project = Project.create({
             id: "",
             name: "AF_Administrators",
             type: "groups",
-            permissions: Permission.initialPermissions(),
+            permissions: Permission.noPermissions(),
         },
         {
             id: "",
             name: "AF_Users",
             type: "groups",
-            permissions: Permission.initialPermissions(),
+            permissions: Permission.noPermissions(),
         },
     ],
 });

--- a/src/domain/entities/__tests__/DataSet.spec.ts
+++ b/src/domain/entities/__tests__/DataSet.spec.ts
@@ -1,4 +1,5 @@
 import { DataSet, DataSetAttrs } from "$/domain/entities/DataSet";
+import { Permission } from "$/domain/entities/Permission";
 import { Project } from "$/domain/entities/Project";
 import { getErrorMessageFromErrors } from "$/domain/entities/generic/Error";
 import { configTest } from "$/utils/tests";
@@ -13,6 +14,20 @@ const projectTest: Project = Project.create({
     lastUpdated: new Date().toISOString(),
     orgsUnits: [],
     dataSets: [],
+    access: [
+        {
+            id: "",
+            name: "AF_Administrators",
+            type: "groups",
+            permissions: Permission.initialPermissions(),
+        },
+        {
+            id: "",
+            name: "AF_Users",
+            type: "groups",
+            permissions: Permission.initialPermissions(),
+        },
+    ],
 });
 
 describe("DataSet", () => {
@@ -55,7 +70,7 @@ describe("DataSet", () => {
         expectUserGroups(dataSetToSave);
     });
 
-    it("should have access groups from project code", async () => {
+    it("should have access groups from project access groups", async () => {
         const dataSetToSave = createDataSet({
             name: "Test DataSet",
             indicators: [],


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697rj6fy

### :memo: Implementation

- [x] Get sharing settings for projects
- [x] Instead checking the first two letters of the project code now we replicate the same sharing settings from the project to the dataSet.

### :video_camera: Screenshots/Screen capture

[Project-Configuration-app_multiple_sharing_settings.webm](https://github.com/user-attachments/assets/0d9021df-8ba8-43c8-89db-673f9547fe2a)

### :fire: Notes to the tester

#8697rj6fy