### PR TITLE
disable close drawer by clicking on backdrop

### DIFF
--- a/src/webapp/components/dataset-wizard/FilterIndicators.tsx
+++ b/src/webapp/components/dataset-wizard/FilterIndicators.tsx
@@ -42,15 +42,6 @@ export type FilterMode = "default" | "drawer";
 export const FilterWrapper = React.memo((props: FilterWrapperProps) => {
     const { children, mode, showDrawer, onClose } = props;
 
-    const closeOnEscape = React.useCallback(
-        (_event: unknown, reason: "backdropClick" | "escapeKeyDown") => {
-            if (reason === "escapeKeyDown" && onClose) {
-                onClose();
-            }
-        },
-        [onClose]
-    );
-
     switch (mode) {
         case "default":
             return (
@@ -60,7 +51,7 @@ export const FilterWrapper = React.memo((props: FilterWrapperProps) => {
             );
         case "drawer":
             return (
-                <Drawer onClose={closeOnEscape} open={showDrawer}>
+                <Drawer onClose={onClose} open={showDrawer}>
                     {children}
                 </Drawer>
             );

--- a/src/webapp/components/dataset-wizard/FilterIndicators.tsx
+++ b/src/webapp/components/dataset-wizard/FilterIndicators.tsx
@@ -34,12 +34,23 @@ export type FilterWrapperProps = {
     mode: FilterMode;
     children: React.JSX.Element;
     showDrawer: boolean;
+    onClose: () => void;
 };
 
 export type FilterMode = "default" | "drawer";
 
 export const FilterWrapper = React.memo((props: FilterWrapperProps) => {
-    const { children, mode, showDrawer } = props;
+    const { children, mode, showDrawer, onClose } = props;
+
+    const closeOnEscape = React.useCallback(
+        (_event: unknown, reason: "backdropClick" | "escapeKeyDown") => {
+            if (reason === "escapeKeyDown" && onClose) {
+                onClose();
+            }
+        },
+        [onClose]
+    );
+
     switch (mode) {
         case "default":
             return (
@@ -48,7 +59,11 @@ export const FilterWrapper = React.memo((props: FilterWrapperProps) => {
                 </Grid>
             );
         case "drawer":
-            return <Drawer open={showDrawer}>{children}</Drawer>;
+            return (
+                <Drawer onClose={closeOnEscape} open={showDrawer}>
+                    {children}
+                </Drawer>
+            );
         default:
             return null;
     }

--- a/src/webapp/components/dataset-wizard/IndicatorsDataSet.tsx
+++ b/src/webapp/components/dataset-wizard/IndicatorsDataSet.tsx
@@ -172,6 +172,7 @@ export const IndicatorsDataSet = React.memo((props: IndicatorsDataSetProps) => {
                 <FilterWrapper
                     mode={isLargeDesktop ? "default" : "drawer"}
                     showDrawer={showFilterModal}
+                    onClose={() => setShowFilterModal(false)}
                 >
                     <FilterIndicators
                         measures={allMeasures}


### PR DESCRIPTION
### :pushpin: References

- **Issue:** Closes https://app.clickup.com/t/8698zhecd

### :memo: Implementation

- [x] disable closing the drawer by clicking on backdrop

### :video_camera: Screenshots/Screen capture

[Project-Configuration-app_click_outside_drawer.webm](https://github.com/user-attachments/assets/ba2e4c4d-dec3-4d0e-8103-876503532fe8)

### :fire: Notes to the tester

You can still close the modal by pressing the `ESC` key for accessibility purposes.

#8698zhecd