### PR TITLE
only show user's org. units

### DIFF
--- a/src/data/repositories/UserD2Repository.ts
+++ b/src/data/repositories/UserD2Repository.ts
@@ -35,6 +35,7 @@ export class UserD2Repository implements UserRepository {
                 canCreateDataSets: hasAccess(authorities.dataSets.create),
                 canEditCombinations: hasAccess(authorities.categoryCombo.edit),
             },
+            orgUnits: d2User.organisationUnits,
         });
     }
 }
@@ -47,6 +48,7 @@ const userFields = {
         username: true,
         userRoles: { id: true, name: true, authorities: true },
     },
+    organisationUnits: true,
 } as const;
 
 type D2User = MetadataPick<{ users: { fields: typeof userFields } }>["users"][number];

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -1,5 +1,5 @@
 import { Struct } from "./generic/Struct";
-import { NamedRef } from "./Ref";
+import { NamedRef, Ref } from "./Ref";
 
 export interface UserAttrs {
     id: string;
@@ -13,6 +13,7 @@ export interface UserAttrs {
         canEditCombinations: boolean;
         canDeleteDataSets: boolean;
     };
+    orgUnits: Ref[];
 }
 
 export interface UserRole extends NamedRef {
@@ -20,6 +21,10 @@ export interface UserRole extends NamedRef {
 }
 
 export class User extends Struct<UserAttrs>() {
+    get orgUnitIds() {
+        return this.orgUnits.map(({ id }) => id);
+    }
+
     belongToUserGroup(userGroupUid: string): boolean {
         return this.userGroups.some(({ id }) => id === userGroupUid);
     }

--- a/src/domain/entities/__tests__/userFixtures.ts
+++ b/src/domain/entities/__tests__/userFixtures.ts
@@ -24,10 +24,12 @@ export function createUserWithGroups(userGroups: NamedRef[] = []): User {
             canCreateDataSets: true,
             canEditCombinations: true,
         },
+        orgUnits: [],
     });
 }
 function createUser(userRoles: UserRole[], userGroups: NamedRef[] = []): User {
     return new User({
+        orgUnits: [],
         id: "kQiwoyMYHBS",
         name: "John Traore",
         username: "user",

--- a/src/webapp/components/dataset-wizard/SetupDataSet.tsx
+++ b/src/webapp/components/dataset-wizard/SetupDataSet.tsx
@@ -31,7 +31,7 @@ export type SetupDataSetProps = {
 };
 
 const SetupDataSet_ = React.memo((props: SetupDataSetProps) => {
-    const { api, config, compositionRoot } = useAppContext();
+    const { api, config, compositionRoot, currentUser } = useAppContext();
     const { dataSet, onChange, onValidate, validationStatus } = props;
     const [projectModalOpen, setProjectModalOpen] = React.useState(false);
     const [showClosedProjects, setShowClosedProjects] = React.useState(false);
@@ -174,6 +174,7 @@ const SetupDataSet_ = React.memo((props: SetupDataSetProps) => {
                     api={api}
                     selected={dataSet.orgUnits.map(orgUnit => `/${orgUnit.path.join("/")}`)}
                     onChange={updateOrgUnits}
+                    rootIds={currentUser.orgUnitIds}
                 />
             </Grid>
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699djjh4

### :memo: Implementation

- [x] Only show org. units that are assigned to the current user (capture org. units)

### :video_camera: Screenshots/Screen capture

![image](https://github.com/user-attachments/assets/f443c3cb-9d71-4008-9700-6a6df4099d44)

### :fire: Notes to the tester

#8699djjh4