### PR TITLE
Handle saving project without permission

### DIFF
--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -4,6 +4,7 @@ import { Struct } from "$/domain/entities/generic/Struct";
 import i18n from "$/utils/i18n";
 import { Maybe } from "$/utils/ts-utils";
 import _ from "$/domain/entities/generic/Collection";
+import { User } from "$/domain/entities/User";
 
 export type ProjectAttrs = {
     id: Id;
@@ -56,5 +57,15 @@ export class Project extends Struct<ProjectAttrs>() {
      */
     static extractCode(value: string): Maybe<string> {
         return (value.split("_")[0] || "").toUpperCase();
+    }
+
+    canEdit(user: User): boolean {
+        return user.userGroups.some(userGroup =>
+            this.access.some(access =>
+                access.type === "groups" &&
+                access.permissions.metadata.write &&
+                access.id === userGroup.id
+            )
+        );
     }
 }

--- a/src/domain/usecases/SaveDataSetUseCase.ts
+++ b/src/domain/usecases/SaveDataSetUseCase.ts
@@ -74,7 +74,11 @@ export class SaveDataSetUseCase {
         return this.projectRepository.getById(dataSet.project.id).flatMap(project => {
             const orgUnitsAreEqual = this.compareOrgUnits(project, dataSet);
             if (orgUnitsAreEqual) return Future.success(Stats.empty());
-            return this.projectRepository.save(project.setOrgUnits(dataSet.orgUnits));
+            return this.projectRepository.save(project.setOrgUnits(dataSet.orgUnits))
+                .flatMapError(error => {
+                    console.warn("Error saving project, ignoring updates. \n", String(error))
+                    return Future.success(Stats.empty());
+                });
         });
     }
 

--- a/src/domain/usecases/SaveDataSetUseCase.ts
+++ b/src/domain/usecases/SaveDataSetUseCase.ts
@@ -48,7 +48,7 @@ export class SaveDataSetUseCase {
                     return this.dataSetRepository
                         .save([dataSetToSave])
                         .flatMap(() => {
-                            return this.saveProject(dataSet).flatMap(stats => {
+                            return this.saveProject(dataSet, options.user).flatMap(stats => {
                                 return this.sendNotification(options, stats.errorMessage);
                             });
                         })
@@ -69,9 +69,11 @@ export class SaveDataSetUseCase {
         }
     }
 
-    private saveProject(dataSet: DataSet): FutureData<Stats> {
+    private saveProject(dataSet: DataSet, user: User): FutureData<Stats> {
         if (!dataSet.project) return Future.success(Stats.empty());
         return this.projectRepository.getById(dataSet.project.id).flatMap(project => {
+            if(!project.canEdit(user)) return Future.success(Stats.empty());
+
             const orgUnitsAreEqual = this.compareOrgUnits(project, dataSet);
             if (orgUnitsAreEqual) return Future.success(Stats.empty());
             return this.projectRepository.save(project.setOrgUnits(dataSet.orgUnits))


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699f2nn4 [Analyse saving "projects" with a non admin user](https://app.clickup.com/t/8699f2nn4)

### :memo: Implementation
- check user project access before saving
- add handling for silent failure
 
NOTE:
Some group admins (not sure how many but one is `GL_Administrator`) are not accessible by group members which will cause failures in updating project org units.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/5cb20557-e19c-4ecc-a4c2-2df04d4961ac

### :fire: Notes to the tester
