### PR TITLE
save dataSets in smaller chunks to avoid 413 error

### DIFF
--- a/src/scripts/migrate-dataset-project.ts
+++ b/src/scripts/migrate-dataset-project.ts
@@ -1,11 +1,12 @@
 import { command, run, string, option } from "cmd-ts";
 import path from "path";
 import { D2Api } from "$/types/d2-api";
-import { getWebappCompositionRoot } from "$/CompositionRoot";
-import { DataSet } from "$/domain/entities/DataSet";
 import { writeFileSync } from "fs";
-import { ConfigD2Repository } from "$/data/repositories/ConfigD2Repository";
 import { escapeCSVField } from "$/scripts/csv";
+import { NamedRef } from "$/domain/entities/Ref";
+import { chunkRequest } from "$/data/utils";
+import { Future, FutureData } from "$/domain/entities/generic/Future";
+import { apiToFuture } from "$/data/api-futures";
 
 function main() {
     const cmd = command({
@@ -32,27 +33,59 @@ function main() {
         handler: async args => {
             const auth = { username: args.username, password: args.password };
             const api = new D2Api({ baseUrl: args.url, auth: auth });
-            const configRepository = new ConfigD2Repository(api);
-            const config = await configRepository.get().toPromise();
-            const compositionRoot = getWebappCompositionRoot(api, config);
-            compositionRoot.dataSets.migrateProjects.execute().run(
-                response => {
-                    console.debug("DataSets saved");
-                    const csvProjectsFileName = "ds_with_projects.csv";
-                    const csvNoProjectsFileName = "ds_without_projects.csv";
-                    writeFileSync(csvProjectsFileName, generateCSV(response.dataSetsWithProjects));
-                    writeFileSync(
-                        csvNoProjectsFileName,
-                        generateCSV(response.dataSetsWithoutProjects)
-                    );
-                    console.debug(
-                        `CSV reports generated: ${csvProjectsFileName} and ${csvNoProjectsFileName}`
-                    );
-                },
-                error => {
-                    console.error(error);
-                    process.exit(1);
-                }
+
+            const attributeProject = await api.models.attributes
+                .get({
+                    fields: { id: true },
+                    filter: { code: { eq: "GL_DATASET_PROJECT" } },
+                    paging: false,
+                })
+                .getData();
+
+            const categoryCode = await api.models.categories
+                .get({
+                    fields: { id: true },
+                    filter: { code: { eq: "GL_Project" } },
+                    paging: false,
+                })
+                .getData();
+
+            if (!categoryCode.objects[0]) throw new Error("Category GL_Project not found");
+
+            const attributeProjectId = attributeProject.objects[0]?.id;
+            if (!attributeProjectId) throw new Error("Attribute GL_DATASET_PROJECT not found");
+
+            const projects = await getAllProjects({
+                api,
+                page: 1,
+                records: [],
+            });
+            const dataSets = await getAllDataSets({
+                api,
+                page: 1,
+                records: [],
+            });
+
+            const allDataSetsProjects = assignProjectsToDataSets(dataSets, projects);
+
+            const dataSetsWithProjects = allDataSetsProjects.filter(ds => ds.project);
+            const dataSetsWithoutProjects = allDataSetsProjects.filter(ds => !ds.project);
+            console.debug("DataSets with projects", dataSetsWithProjects.length);
+            console.debug("DataSets without projects", dataSetsWithoutProjects.length);
+            console.debug(`Saving ${dataSetsWithProjects.length} dataSets...`);
+
+            await saveDataSet({
+                api,
+                attributeProjectId: attributeProjectId,
+                dataSets: dataSetsWithProjects,
+            }).toPromise();
+
+            const csvProjectsFileName = "ds_with_projects.csv";
+            const csvNoProjectsFileName = "ds_without_projects.csv";
+            writeFileSync(csvProjectsFileName, generateCSV(dataSetsWithProjects));
+            writeFileSync(csvNoProjectsFileName, generateCSV(dataSetsWithoutProjects));
+            console.debug(
+                `CSV reports generated: ${csvProjectsFileName} and ${csvNoProjectsFileName}`
             );
         },
     });
@@ -60,7 +93,146 @@ function main() {
     run(cmd, process.argv.slice(2));
 }
 
-function generateCSV(data: DataSet[]): string {
+function assignProjectsToDataSets(
+    dataSets: DataSetProject[],
+    projects: NamedRef[]
+): DataSetProject[] {
+    return dataSets.map(dataSet => {
+        const project = projects.find(project => dataSet.name.includes(project.name));
+        return { ...dataSet, project: project };
+    });
+}
+
+function saveDataSet(options: {
+    api: D2Api;
+    dataSets: DataSetProject[];
+    attributeProjectId: string;
+}): FutureData<void> {
+    const { attributeProjectId, api, dataSets } = options;
+
+    const allDsIds = dataSets.map(ds => ds.id);
+
+    const $requests = chunkRequest(allDsIds, dataSetIds => {
+        return apiToFuture(
+            api.models.dataSets.get({
+                fields: { $owner: true },
+                filter: { id: { in: dataSetIds } },
+                paging: false,
+            })
+        ).flatMap(response => {
+            const dataSetsToSave = dataSetIds.map(dataSetId => {
+                const existingDataSet = response.objects.find(ds => ds.id === dataSetId);
+                const dataSet = dataSets.find(dataSet => dataSet.id === dataSetId);
+                if (!dataSet) {
+                    throw Error(`Cannot find dataSet: ${dataSetId}`);
+                }
+
+                const projectAttribute = {
+                    attribute: { id: attributeProjectId },
+                    value: dataSet.project?.id,
+                };
+
+                const attributesToSave = [projectAttribute].filter(attr => attr.value);
+
+                const filteredExisting =
+                    existingDataSet?.attributeValues?.filter(
+                        attr =>
+                            !attributesToSave.some(save => save.attribute.id === attr.attribute.id)
+                    ) || [];
+
+                const attributeValues = [...filteredExisting, ...attributesToSave];
+
+                return { ...(existingDataSet || {}), attributeValues: attributeValues };
+            });
+
+            return apiToFuture(
+                api.metadata.post({ dataSets: dataSetsToSave }, { importMode: "COMMIT" })
+            )
+                .map(response => {
+                    return [{ ...response.stats }];
+                })
+                .flatMapError(err => {
+                    console.error("Error saving dataSets:", err);
+                    return Future.success([]);
+                });
+        });
+    });
+
+    return $requests.map(stats => {
+        const allStats = stats.reduce(
+            (acc, curr) => {
+                acc.created += curr.created;
+                acc.updated += curr.updated;
+                acc.deleted += curr.deleted;
+                acc.ignored += curr.ignored;
+                return acc;
+            },
+            { created: 0, updated: 0, deleted: 0, ignored: 0 }
+        );
+
+        console.debug("Finished");
+        console.debug(JSON.stringify(allStats, null, 2));
+    });
+}
+
+async function getAllDataSets(options: { api: D2Api; page: number; records: NamedRef[] }) {
+    const { records, api, page } = options;
+
+    const response = await getDataSets({ api, page, pageSize: 200 });
+    const newProjects = [...records, ...response.data];
+    if (response.pager.page >= response.pager.pageCount) {
+        return newProjects;
+    } else {
+        return getAllDataSets({ api, page: page + 1, records: newProjects });
+    }
+}
+
+async function getAllProjects(options: { api: D2Api; page: number; records: NamedRef[] }) {
+    const { records, api, page } = options;
+
+    const response = await getProjects({ api, page, pageSize: 200 });
+    const newProjects = [...records, ...response.data];
+    if (response.pager.page >= response.pager.pageCount) {
+        return newProjects;
+    } else {
+        return getAllProjects({ api, page: page + 1, records: newProjects });
+    }
+}
+
+async function getProjects(options: { api: D2Api; page: number; pageSize: number }) {
+    const { api, page, pageSize } = options;
+    const response = await api.models.categoryOptions
+        .get({
+            filter: { "categories.code": { eq: "GL_Project" } },
+            page: page,
+            pageSize: pageSize,
+            fields: { id: true, code: true, displayName: true },
+        })
+        .getData();
+
+    return {
+        data: response.objects.map(item => ({ id: item.id, name: item.displayName })),
+        pager: response.pager,
+    };
+}
+
+async function getDataSets(options: { api: D2Api; page: number; pageSize: number }) {
+    const { api, page, pageSize } = options;
+    const response = await api.models.dataSets
+        .get({ page: page, pageSize: pageSize, fields: { id: true, displayName: true } })
+        .getData();
+
+    return {
+        data: response.objects.map(item => ({
+            id: item.id,
+            name: item.displayName,
+            project: undefined,
+        })),
+        pager: response.pager,
+    };
+}
+
+function generateCSV(data: DataSetProject[]): string {
     const headers = ["id", "name", "project"];
     const rows = data.map(dataset =>
         [
@@ -72,5 +244,11 @@ function generateCSV(data: DataSet[]): string {
     const csvContent = [headers.join(","), ...rows].join("\n");
     return csvContent;
 }
+
+type DataSetProject = {
+    id: string;
+    name: string;
+    project?: NamedRef;
+};
 
 main();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699m6ghc

### :memo: Implementation

### :video_camera: Screenshots/Screen capture

```shell
> d2-dataset-configuration@2.7.1 migrate-ds-project
> npx ts-node src/scripts/migrate-dataset-project.ts --dhis2-url [url] --username [username] --password [password]

DataSets with projects 1258
DataSets without projects 186
Saving 1258 dataSets...
Finished
{
  "created": 0,
  "updated": 1258,
  "deleted": 0,
  "ignored": 0
}
CSV reports generated: ds_with_projects.csv and ds_without_projects.csv
```

### :fire: Notes to the tester

#8699m6ghc