### PR TITLE
Fix: add period dates and update data entry

### DIFF
--- a/src/data/D2ApiIndicator.ts
+++ b/src/data/D2ApiIndicator.ts
@@ -277,7 +277,6 @@ export class D2ApiIndicator {
         const hideInApp = dataElement.attributeValues.find(
             attribute => attribute.attribute.id === config.attributes.hideInApp.id
         );
-        if (hideInApp) console.log(hideInApp, dataElement);
         if (hideInApp && hideInApp.value === "true") return undefined;
 
         const theme = dataElement.dataElementGroups.find(deg =>

--- a/src/data/entry-form/CustomForm.ts
+++ b/src/data/entry-form/CustomForm.ts
@@ -19,6 +19,7 @@ import { convertAttributeValueToDate } from "$/data/utils";
 import templateVelocity from "$/data/entry-form/template.vm?raw";
 import templateJs from "$/data/entry-form/template.js?raw";
 import templateCss from "$/data/entry-form/template.css?raw";
+import { toISODateWithoutTimezone } from "$/utils/date";
 
 function getCategoryCombo(dataSetElement: DataSetTemplate["dataSetElements"][0]) {
     const { categoryCombo } = dataSetElement;
@@ -454,8 +455,10 @@ function generatePeriodsFromAttributeValues(
             return [
                 year,
                 {
-                    start: convertAttributeValueToDate(startDate),
-                    end: convertAttributeValueToDate(endDate),
+                    start: toISODateWithoutTimezone(
+                        new Date(convertAttributeValueToDate(startDate))
+                    ),
+                    end: toISODateWithoutTimezone(new Date(convertAttributeValueToDate(endDate))),
                 },
             ] as [string, TemplateDate];
         })

--- a/src/data/entry-form/CustomForm.ts
+++ b/src/data/entry-form/CustomForm.ts
@@ -423,18 +423,14 @@ function mapDataElementRefs(
 }
 
 function generatePeriods(dataSet: DataSetTemplate, d2Config: D2Config): Maybe<TemplatePeriodDate> {
-    const outComeAttribute = dataSet.attributeValues.find(
-        attr => attr.attribute.id === d2Config.attributes.outcomeDates.id
+    const periodDates = dataSet.attributeValues.find(
+        attr => attr.attribute.id === d2Config.attributes.periodDates.id
     );
-    const outPutAttribute = dataSet.attributeValues.find(
-        attr => attr.attribute.id === d2Config.attributes.outputDates.id
-    );
-    if (!outComeAttribute || !outPutAttribute) return undefined;
+    if (!periodDates) return undefined;
 
-    const outComeValidYears = generatePeriodsFromAttributeValues(outComeAttribute);
-    const outPutValidYears = generatePeriodsFromAttributeValues(outPutAttribute);
+    const periodDateValidYears = generatePeriodsFromAttributeValues(periodDates);
 
-    return { output: outPutValidYears, outcome: outComeValidYears };
+    return { output: periodDateValidYears, outcome: periodDateValidYears };
 }
 
 function generateIndicatorMatchingReference(dataSet: DataSet) {

--- a/src/data/repositories/DataSetD2Repository.ts
+++ b/src/data/repositories/DataSetD2Repository.ts
@@ -687,6 +687,14 @@ export class DataSetD2Repository implements DataSetRepository {
             notifyCompletingUser: dataSet.notifyUser,
             openFuturePeriods: dataSet.openFuturePeriods,
             expiryDays: dataSet.expiryDays,
+            dataInputPeriods:
+                dataSet.periodDate?.dataInputPeriods.map(p => ({
+                    closingDate: p.endDate,
+                    openingDate: p.startDate,
+                    period: {
+                        id: p.period,
+                    },
+                })) ?? [],
         };
     }
 
@@ -877,4 +885,5 @@ type D2DataSetToSave = {
         users: Record<Id, D2ApiSharingName>;
         userGroups: Record<Id, D2ApiSharingName>;
     };
+    dataInputPeriods: { closingDate: string; openingDate: string; period: Ref }[];
 };

--- a/src/data/repositories/DataSetD2Repository.ts
+++ b/src/data/repositories/DataSetD2Repository.ts
@@ -687,14 +687,7 @@ export class DataSetD2Repository implements DataSetRepository {
             notifyCompletingUser: dataSet.notifyUser,
             openFuturePeriods: dataSet.openFuturePeriods,
             expiryDays: dataSet.expiryDays,
-            dataInputPeriods:
-                dataSet.periodDate?.dataInputPeriods.map(p => ({
-                    closingDate: p.endDate,
-                    openingDate: p.startDate,
-                    period: {
-                        id: p.period,
-                    },
-                })) ?? [],
+            dataInputPeriods: this.buildDataInputPeriod(dataSet),
         };
     }
 
@@ -752,6 +745,18 @@ export class DataSetD2Repository implements DataSetRepository {
             ) || [];
 
         return [...filteredExisting, ...attributesToSave];
+    }
+
+    private buildDataInputPeriod(dataSet: DataSetToSave): D2DataSetToSave["dataInputPeriods"] {
+        return (
+            dataSet.periodDate?.dataInputPeriods.map(p => ({
+                closingDate: p.endDate,
+                openingDate: p.startDate,
+                period: {
+                    id: p.period,
+                },
+            })) ?? []
+        );
     }
 
     private parsePeriodDate(

--- a/src/domain/entities/DataSet.ts
+++ b/src/domain/entities/DataSet.ts
@@ -73,6 +73,15 @@ export class DataSet extends Struct<DataSetAttrs>() {
         const orgsUnits = project ? project.orgsUnits : this.orgUnits;
 
         const accessGroupsFromProject = this.getAccessFromProject(project, config);
+        //TODO: confirm period data value when project updates
+        const periodDate =
+            project?.startDate && project?.endDate
+                ? DatePeriod.create({
+                      startDate: project.startDate,
+                      endDate: project.endDate,
+                      periods: [],
+                  }).initializePeriods(config)
+                : undefined;
 
         return this._update({
             access: accessGroupsFromProject,
@@ -80,6 +89,8 @@ export class DataSet extends Struct<DataSetAttrs>() {
             project,
             name,
             orgUnits: orgsUnits,
+            periodDate,
+            openFuturePeriods: DatePeriod.getFuturePeriods(periodDate?.endDate),
         });
     }
 

--- a/src/domain/entities/DataSet.ts
+++ b/src/domain/entities/DataSet.ts
@@ -74,6 +74,7 @@ export class DataSet extends Struct<DataSetAttrs>() {
 
         const accessGroupsFromProject = this.getAccessFromProject(project, config);
         //TODO: confirm period data value when project updates
+        // should default be current periodDate or undefined?
         const periodDate =
             project?.startDate && project?.endDate
                 ? DatePeriod.create({

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -1,6 +1,6 @@
 import { Struct } from "$/domain/entities/generic/Struct";
 import { Config } from "$/domain/entities/Config";
-import { addToDate, formatDateToISO, getDiff, stringToTime } from "$/utils/date";
+import { addToDate, toISODateWithoutTimezone, getDiff, stringToTime } from "$/utils/date";
 import _, { Collection } from "$/domain/entities/generic/Collection";
 import { Maybe } from "$/utils/ts-utils";
 
@@ -71,8 +71,8 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
                 return MonthlyPeriodDetails.create({
                     year: targetYear,
                     month: targetMonth,
-                    startDate: formatDateToISO(openingDate),
-                    endDate: formatDateToISO(closingDate),
+                    startDate: toISODateWithoutTimezone(openingDate),
+                    endDate: toISODateWithoutTimezone(closingDate),
                 });
             })
             .value();
@@ -113,7 +113,7 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
     private buildShortFormat(date: string) {
         if (!date) return "";
 
-        const datePart = formatDateToISO(new Date(date)).split("T")[0];
+        const datePart = toISODateWithoutTimezone(new Date(date)).split("T")[0];
         if (!datePart) return "";
         return datePart.replace(/-/g, "");
     }

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -41,14 +41,10 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
             return [];
         }
 
-        const allStartTimes = _(periods)
-            .compactMap(p => stringToTime(p.startDate))
-            .value();
-        const allEndTime = _(periods)
-            .compactMap(p => stringToTime(p.endDate))
-            .value();
+        const allStartTimes = this.extractPeriodDateAsTimes("startDate");
+        const allEndTimes = this.extractPeriodDateAsTimes("endDate");
 
-        if (!allStartTimes.length || !allEndTime.length) {
+        if (!allStartTimes.length || !allEndTimes.length) {
             return [];
         }
 
@@ -56,7 +52,7 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         const endDate = new Date(endDateStr);
 
         const openingDate = new Date(Math.min(...allStartTimes, startDate.getTime()));
-        const closingDate = new Date(Math.max(...allEndTime, endDate.getTime()));
+        const closingDate = new Date(Math.max(...allEndTimes, endDate.getTime()));
 
         const startYear = startDate.getFullYear();
         const startMonth = startDate.getMonth();
@@ -75,6 +71,12 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
                     endDate: toISODateWithoutTimezone(closingDate),
                 });
             })
+            .value();
+    }
+
+    private extractPeriodDateAsTimes<K extends "startDate" | "endDate">(field: K) {
+        return _(this.periods)
+            .compactMap(p => stringToTime(p[field]))
             .value();
     }
 

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -1,6 +1,6 @@
 import { Struct } from "$/domain/entities/generic/Struct";
 import { Config } from "$/domain/entities/Config";
-import { addToDate, getDiff, stringToTime } from "$/utils/date";
+import { addToDate, formatDateToISO, getDiff, stringToTime } from "$/utils/date";
 import _, { Collection } from "$/domain/entities/generic/Collection";
 import { Maybe } from "$/utils/ts-utils";
 
@@ -71,8 +71,8 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
                 return MonthlyPeriodDetails.create({
                     year: targetYear,
                     month: targetMonth,
-                    startDate: openingDate.toISOString(),
-                    endDate: closingDate.toISOString(),
+                    startDate: formatDateToISO(openingDate),
+                    endDate: formatDateToISO(closingDate),
                 });
             })
             .value();
@@ -113,7 +113,7 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
     private buildShortFormat(date: string) {
         if (!date) return "";
 
-        const datePart = new Date(date).toISOString().split("T")[0];
+        const datePart = formatDateToISO(new Date(date)).split("T")[0];
         if (!datePart) return "";
         return datePart.replace(/-/g, "");
     }

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -1,6 +1,6 @@
 import { Struct } from "$/domain/entities/generic/Struct";
 import { Config } from "$/domain/entities/Config";
-import { addToDate, stringToTime } from "$/utils/date";
+import { addToDate, getDiff, stringToTime } from "$/utils/date";
 import _, { Collection } from "$/domain/entities/generic/Collection";
 import { Maybe } from "$/utils/ts-utils";
 
@@ -61,8 +61,7 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         const startYear = startDate.getFullYear();
         const startMonth = startDate.getMonth();
 
-        const totalMonths =
-            (endDate.getFullYear() - startYear) * 12 + (endDate.getMonth() - startMonth) + 1;
+        const totalMonths = Math.round(getDiff(startDate, endDate, "month"));
 
         return Collection.range(0, totalMonths)
             .map(monthOffset => {
@@ -143,8 +142,7 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         const end = new Date(endDateStr);
         const now = new Date();
 
-        const monthsDiff =
-            (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth());
+        const monthsDiff = Math.ceil(getDiff(now, end, "month"));
 
         return Math.max(monthsDiff + 1, DEFAULT_FUTURE_PERIODS);
     }

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -146,7 +146,6 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         const monthsDiff =
             (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth());
 
-        console.log("test", end, now, monthsDiff);
         return Math.max(monthsDiff + 1, DEFAULT_FUTURE_PERIODS);
     }
 }

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -2,6 +2,9 @@ import { Struct } from "$/domain/entities/generic/Struct";
 import { Config } from "$/domain/entities/Config";
 import { addToDate, stringToTime } from "$/utils/date";
 import _, { Collection } from "$/domain/entities/generic/Collection";
+import { Maybe } from "$/utils/ts-utils";
+
+const DEFAULT_FUTURE_PERIODS = 1;
 
 export type YearlyPeriodDetailsAttrs = {
     year: number;
@@ -32,15 +35,16 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         }));
     }
 
-    get monthlyPeriod(): MonthlyPeriodDetails[] {
-        if (!this.periods || this.periods.length === 0) {
+    get dataInputPeriods(): MonthlyPeriodDetails[] {
+        const { periods, startDate: startDateStr, endDate: endDateStr } = this;
+        if (!periods.length) {
             return [];
         }
 
-        const allStartTimes = _(this.periods)
+        const allStartTimes = _(periods)
             .compactMap(p => stringToTime(p.startDate))
             .value();
-        const allEndTime = _(this.periods)
+        const allEndTime = _(periods)
             .compactMap(p => stringToTime(p.endDate))
             .value();
 
@@ -48,22 +52,30 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
             return [];
         }
 
-        const minStartDate = new Date(Math.min(...allStartTimes));
-        const maxEndDate = new Date(Math.max(...allEndTime));
+        const startDate = new Date(startDateStr);
+        const endDate = new Date(endDateStr);
 
-        const months = Collection.range(0, 12);
+        const openingDate = new Date(Math.min(...allStartTimes, startDate.getTime()));
+        const closingDate = new Date(Math.max(...allEndTime, endDate.getTime()));
 
-        return _(this.periods)
-            .flatMap(yearPeriod =>
-                months.map(month =>
-                    MonthlyPeriodDetails.create({
-                        year: yearPeriod.year,
-                        month: month + 1,
-                        startDate: minStartDate.toISOString(),
-                        endDate: maxEndDate.toISOString(),
-                    })
-                )
-            )
+        const startYear = startDate.getFullYear();
+        const startMonth = startDate.getMonth();
+
+        const totalMonths =
+            (endDate.getFullYear() - startYear) * 12 + (endDate.getMonth() - startMonth) + 1;
+
+        return Collection.range(0, totalMonths)
+            .map(monthOffset => {
+                const targetYear = startYear + Math.floor((startMonth + monthOffset) / 12);
+                const targetMonth = ((startMonth + monthOffset) % 12) + 1;
+
+                return MonthlyPeriodDetails.create({
+                    year: targetYear,
+                    month: targetMonth,
+                    startDate: openingDate.toISOString(),
+                    endDate: closingDate.toISOString(),
+                });
+            })
             .value();
     }
 
@@ -94,6 +106,11 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         });
     }
 
+    initializePeriods(config: DataPeriodConfig): DatePeriod {
+        const periods = this.generatePeriods(config);
+        return this.updatedPeriods(periods);
+    }
+
     private buildShortFormat(date: string) {
         if (!date) return "";
 
@@ -118,6 +135,19 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
 
     updatedPeriods(periods: YearlyPeriodDetailsAttrs[]): DatePeriod {
         return this._update({ periods });
+    }
+
+    static getFuturePeriods(endDateStr: Maybe<string>): number {
+        if (!endDateStr) return DEFAULT_FUTURE_PERIODS;
+
+        const end = new Date(endDateStr);
+        const now = new Date();
+
+        const monthsDiff =
+            (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth());
+
+        console.log("test", end, now, monthsDiff);
+        return Math.max(monthsDiff + 1, DEFAULT_FUTURE_PERIODS);
     }
 }
 

--- a/src/domain/entities/DatePeriod.ts
+++ b/src/domain/entities/DatePeriod.ts
@@ -1,7 +1,15 @@
 import { Struct } from "$/domain/entities/generic/Struct";
+import { Config } from "$/domain/entities/Config";
+import { addToDate, stringToTime } from "$/utils/date";
+import _, { Collection } from "$/domain/entities/generic/Collection";
 
-export type PeriodDetailsAttrs = { year: number; startDate: string; endDate: string };
-type DatePeriodAttrs = { startDate: string; endDate: string; periods: PeriodDetailsAttrs[] };
+export type YearlyPeriodDetailsAttrs = {
+    year: number;
+    startDate: string;
+    endDate: string;
+};
+
+type DatePeriodAttrs = { startDate: string; endDate: string; periods: YearlyPeriodDetailsAttrs[] };
 
 export class DatePeriod extends Struct<DatePeriodAttrs>() {
     get years() {
@@ -22,6 +30,68 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
             startDate: this.buildShortFormat(period.startDate),
             endDate: this.buildShortFormat(period.endDate),
         }));
+    }
+
+    get monthlyPeriod(): MonthlyPeriodDetails[] {
+        if (!this.periods || this.periods.length === 0) {
+            return [];
+        }
+
+        const allStartTimes = _(this.periods)
+            .compactMap(p => stringToTime(p.startDate))
+            .value();
+        const allEndTime = _(this.periods)
+            .compactMap(p => stringToTime(p.endDate))
+            .value();
+
+        if (!allStartTimes.length || !allEndTime.length) {
+            return [];
+        }
+
+        const minStartDate = new Date(Math.min(...allStartTimes));
+        const maxEndDate = new Date(Math.max(...allEndTime));
+
+        const months = Collection.range(0, 12);
+
+        return _(this.periods)
+            .flatMap(yearPeriod =>
+                months.map(month =>
+                    MonthlyPeriodDetails.create({
+                        year: yearPeriod.year,
+                        month: month + 1,
+                        startDate: minStartDate.toISOString(),
+                        endDate: maxEndDate.toISOString(),
+                    })
+                )
+            )
+            .value();
+    }
+
+    generatePeriods(config: DataPeriodConfig): DatePeriod["periods"] {
+        const { startDate, endDate, periods, years } = this;
+
+        const month = config.periodEndDateMonth;
+        const day = config.periodEndDateDay;
+        const units = config.periodLastYearUnits;
+        const unitValue = config.periodLastYearEndDate;
+        const lastYear = years[years.length - 1];
+
+        return years.map(year => {
+            const currentPeriod = periods.find(period => period.year === year);
+
+            const defaultEndDate = new Date(year + 1, month - 1, day, 0, 0, 0).toISOString();
+
+            const lastYearEndDate =
+                units && unitValue ? addToDate(endDate ?? "", units, unitValue) : endDate;
+
+            const endM = year === lastYear ? lastYearEndDate : defaultEndDate;
+
+            return {
+                year,
+                startDate: currentPeriod?.startDate ?? startDate ?? "",
+                endDate: currentPeriod?.endDate ?? endM ?? "",
+            };
+        });
     }
 
     private buildShortFormat(date: string) {
@@ -46,7 +116,19 @@ export class DatePeriod extends Struct<DatePeriodAttrs>() {
         return this._update({ [fieldName]: value });
     }
 
-    updatedPeriods(periods: PeriodDetailsAttrs[]): DatePeriod {
+    updatedPeriods(periods: YearlyPeriodDetailsAttrs[]): DatePeriod {
         return this._update({ periods });
     }
 }
+
+export type MonthlyPeriodDetailsAttrs = YearlyPeriodDetailsAttrs & { month: number };
+export class MonthlyPeriodDetails extends Struct<MonthlyPeriodDetailsAttrs>() {
+    get period() {
+        return `${this.year}${String(this.month).padStart(2, "0")}`;
+    }
+}
+
+type DataPeriodConfig = Pick<
+    Config,
+    "periodEndDateMonth" | "periodEndDateDay" | "periodLastYearUnits" | "periodLastYearEndDate"
+>;

--- a/src/domain/usecases/SavePeriodDateUseCase.ts
+++ b/src/domain/usecases/SavePeriodDateUseCase.ts
@@ -22,7 +22,11 @@ export class SavePeriodDateUseCase {
         return this.getDataSetsByIds(options.dataSetsIds).flatMap(dataSets => {
             return this.userUtils.checkDataSetAccess(dataSets).flatMap(() => {
                 const dataSetsToSave = dataSets.map(dataSet => {
-                    return DataSet.create({ ...dataSet, periodDate: options.periodDate });
+                    return DataSet.create({
+                        ...dataSet,
+                        periodDate: options.periodDate,
+                        openFuturePeriods: DatePeriod.getFuturePeriods(options.periodDate.endDate),
+                    });
                 });
                 return this.dataSetRepository
                     .save(dataSetsToSave)

--- a/src/domain/usecases/SavePeriodDateUseCase.ts
+++ b/src/domain/usecases/SavePeriodDateUseCase.ts
@@ -2,7 +2,6 @@ import { Future, FutureData } from "$/domain/entities/generic/Future";
 import { DataSet } from "$/domain/entities/DataSet";
 import { Id } from "$/domain/entities/Ref";
 import { DataSetRepository } from "$/domain/repositories/DataSetRepository";
-import _ from "$/domain/entities/generic/Collection";
 import { LogRepository } from "$/domain/repositories/LogRepository";
 import { UserUtils } from "$/domain/usecases/common/UserUtils";
 import { UserRepository } from "$/domain/repositories/UserRepository";

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -45,22 +45,23 @@ export function getDiff(dateA: Date, dateB: Date, unit: UnitDate): number {
         case "day":
             return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
         case "month": {
-            let monthDiff =
+            const monthDiff =
                 12 * (dateB.getFullYear() - dateA.getFullYear()) +
                 dateB.getMonth() -
                 dateA.getMonth();
-            if (dateA !== dateB) {
+            if (dateA.getTime() !== dateB.getTime()) {
                 const dateADay = dateA.getDate();
                 const dateBDay = dateB.getDate();
-                const daysInCurrentMonth = new Date(
-                    dateA.getFullYear(),
-                    dateA.getMonth() + 1,
+                const daysInMonth = new Date(
+                    dateB.getFullYear(),
+                    dateB.getMonth() + 1,
                     0
                 ).getDate();
-                const dayFraction = (dateBDay - dateADay) / daysInCurrentMonth;
-                monthDiff += dayFraction;
+                const dayFraction = (dateBDay - dateADay) / daysInMonth;
+                return monthDiff + dayFraction;
+            } else {
+                return monthDiff;
             }
-            return monthDiff;
         }
         case "week":
             return Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 7));

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -38,6 +38,36 @@ export function addToDate(date: string, units: UnitDate, unitValue: number): str
     return newDate.toISOString();
 }
 
+export function getDiff(dateA: Date, dateB: Date, unit: UnitDate): number {
+    const diffTime = dateB.getTime() - dateA.getTime();
+
+    switch (unit) {
+        case "day":
+            return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+        case "month":
+            let monthDiff =
+                12 * (dateB.getFullYear() - dateA.getFullYear()) +
+                dateB.getMonth() -
+                dateA.getMonth();
+            if (dateA !== dateB) {
+                const dateADay = dateA.getDate();
+                const dateBDay = dateB.getDate();
+                const daysInCurrentMonth = new Date(
+                    dateA.getFullYear(),
+                    dateA.getMonth() + 1,
+                    0
+                ).getDate();
+                const dayFraction = (dateBDay - dateADay) / daysInCurrentMonth;
+                monthDiff += dayFraction;
+            }
+            return monthDiff;
+        case "week":
+            return Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 7));
+        default:
+            throw new Error("Invalid Date Unit");
+    }
+}
+
 export function getMonths() {
     const currentYear = new Date().getFullYear();
     return Array.from({ length: 12 }, (_, i) => ({

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -44,7 +44,7 @@ export function getDiff(dateA: Date, dateB: Date, unit: UnitDate): number {
     switch (unit) {
         case "day":
             return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        case "month":
+        case "month": {
             let monthDiff =
                 12 * (dateB.getFullYear() - dateA.getFullYear()) +
                 dateB.getMonth() -
@@ -61,6 +61,7 @@ export function getDiff(dateA: Date, dateB: Date, unit: UnitDate): number {
                 monthDiff += dayFraction;
             }
             return monthDiff;
+        }
         case "week":
             return Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 7));
         default:
@@ -97,6 +98,15 @@ export function getDaysPerMonthYear(
         text: String(index + 1),
         value: String(index + 1),
     }));
+}
+
+export function formatDateToISO(date: Date) {
+    const dateParts = [
+        date.getFullYear(),
+        String(date.getMonth() + 1).padStart(2, "0"),
+        String(date.getDate()).padStart(2, "0"),
+    ];
+    return dateParts.join("-") + "T00:00:00.000";
 }
 
 export function stringToTime(dateStr: Maybe<string>): Maybe<number> {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -100,7 +100,7 @@ export function getDaysPerMonthYear(
     }));
 }
 
-export function formatDateToISO(date: Date) {
+export function toISODateWithoutTimezone(date: Date) {
     const dateParts = [
         date.getFullYear(),
         String(date.getMonth() + 1).padStart(2, "0"),

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,6 +2,7 @@ import { ISODateString } from "$/domain/entities/Ref";
 import { UnitDate } from "$/domain/entities/UnitDate";
 import i18n from "$/utils/i18n";
 import { DropdownItem } from "@eyeseetea/d2-ui-components";
+import { Maybe } from "$/utils/ts-utils";
 
 export function toLongDateString(isoDate: ISODateString, options?: Intl.DateTimeFormatOptions) {
     return new Date(isoDate).toLocaleString("default", {
@@ -66,4 +67,9 @@ export function getDaysPerMonthYear(
         text: String(index + 1),
         value: String(index + 1),
     }));
+}
+
+export function stringToTime(dateStr: Maybe<string>): Maybe<number> {
+    const time = dateStr ? new Date(dateStr).getTime() : NaN;
+    return isNaN(time) ? undefined : time;
 }

--- a/src/webapp/components/dataset-periods/DataSetPeriodDates.tsx
+++ b/src/webapp/components/dataset-periods/DataSetPeriodDates.tsx
@@ -5,8 +5,7 @@ import { Typography } from "@material-ui/core";
 
 import { Id } from "$/domain/entities/Ref";
 import { useGetDataSetsByIds } from "$/webapp/hooks/useDataSets";
-import { addToDate } from "$/utils/date";
-import { DatePeriod, PeriodDetailsAttrs } from "$/domain/entities/DatePeriod";
+import { DatePeriod, YearlyPeriodDetailsAttrs } from "$/domain/entities/DatePeriod";
 import i18n from "$/utils/i18n";
 import { useAppContext } from "$/webapp/contexts/app-context";
 
@@ -19,36 +18,8 @@ export type DataSetPeriodDatesProps = {
 function useGetYears(props: { period: DatePeriod }) {
     const { config } = useAppContext();
     const { period } = props;
-    const { startDate, endDate, periods, years } = period;
 
-    const lastYear = years[years.length - 1];
-
-    const periodsByYear = React.useMemo(() => {
-        if (!startDate || !endDate) return [];
-
-        return years.map((year): DatePeriod["periods"][number] => {
-            const month = config.periodEndDateMonth;
-            const day = config.periodEndDateDay;
-            const units = config.periodLastYearUnits;
-            const unitValue = config.periodLastYearEndDate;
-            const currentPeriod = periods.find(period => period.year === year);
-
-            const defaultEndDate = new Date(year + 1, month - 1, day, 0, 0, 0).toISOString();
-
-            const lastYearEndDate =
-                units && unitValue ? addToDate(endDate ?? "", units, unitValue) : endDate;
-
-            const endM = year === lastYear ? lastYearEndDate : defaultEndDate;
-
-            return {
-                year,
-                startDate: currentPeriod?.startDate ?? startDate ?? "",
-                endDate: currentPeriod?.endDate ?? endM ?? "",
-            };
-        });
-    }, [years, startDate, endDate, lastYear, periods, config]);
-
-    return periodsByYear;
+    return React.useMemo(() => period.generatePeriods(config), [period, config]);
 }
 
 const emptyPeriodDate = DatePeriod.create({
@@ -76,7 +47,7 @@ export const DataSetPeriodDates = React.memo((props: DataSetPeriodDatesProps) =>
     });
 
     const updatePeriod = (
-        period: PeriodDetailsAttrs,
+        period: YearlyPeriodDetailsAttrs,
         value: string,
         fieldName: "startDate" | "endDate"
     ) => {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869a9hcp5 [Issue with the dates on the new app](https://app.clickup.com/t/869a9hcp5)

### :memo: Implementation
- generate and save dataInputPeriod
    - `dataInputPeriod` is generated based on attribute `GL_INTERVAL_DATES (Data Input Dates)` 
    - Opening and closing dates are the min startDate and max endDate of `GL_DATASET_PERIOD_DATES (Period Dates)`
- recalculate and save `openFuturePeriods` when selecting project or updating data input dates
- update custom form to use `GL_DATASET_PERIOD_DATES`
- Update date handling:
    - use `toISODateWithoutTimezone` when saving
    - With the current flow, saved short dates are -1 day because of timezone
        1. convert attribute short date (+8 timezone) -> `new Date(2025, 3, 1, 0, 0, 0) April 1 2025 00:00:00 GMT+8`
        2. in saving, we convert this date `toISOString()` then get the date value, which will be `March 31 2025`
            -  `new Date(2025, 3, 1, 0, 0, 0).toISOString()` is `2025-03-31T16:00:00.000Z`

TODO: 
- [ ] confirm period data value when project updates
    - should default be current periodDate or undefined (if project doesn't have start/end dates)

### :video_camera: Screenshots/Screen capture

**CREATE DATA SET**

https://github.com/user-attachments/assets/d6e9f592-ea70-4c30-9cfc-8f87aea718f4

**UPDATE 2027 CLOSING (fields disable fields)**

https://github.com/user-attachments/assets/fb8598aa-4d55-4f6a-be1c-d5dabb8df93e


https://github.com/user-attachments/assets/d3dc77a2-90e2-409d-9f3d-1ba80e1ff4bb



### :fire: Notes to the tester
