### PR TITLE
only admin users can update output/outcome period dates

### DIFF
--- a/src/webapp/components/dataset-table/DataSetTableConfig.tsx
+++ b/src/webapp/components/dataset-table/DataSetTableConfig.tsx
@@ -188,7 +188,7 @@ export function getCommonActions<T extends HasPermission>(
             text: i18n.t("Set output/outcome period dates"),
             icon: <DateRangeIcon />,
             multiple: true,
-            isActive: isActionActive,
+            isActive: rows => isActionActive(rows) && user.isAdmin(),
             onClick: selectedIds => {
                 onAction({ ids: selectedIds, action: "set_period_dates" });
             },


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dntzxq #869dntzxq

### :memo: Implementation

add "isAdmin" validation to the outcome/output period action

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/34302896-795b-4ea9-84b9-ee6f7fea2966

### :fire: Notes to the tester

- In order to test you must create a non admin user