### PR TITLE
avoid empty sharing settings for dataSets when project does not match…

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-12-11T09:29:10.813Z\n"
-"PO-Revision-Date: 2025-12-11T09:29:10.813Z\n"
+"POT-Creation-Date: 2026-07-09T20:12:45.540Z\n"
+"PO-Revision-Date: 2026-07-09T20:12:45.540Z\n"
 
 msgid "edit dataset"
 msgstr ""
@@ -408,6 +408,16 @@ msgid "<No value>"
 msgstr ""
 
 msgid "Select Project"
+msgstr ""
+
+msgid ""
+"Sharing settings is not available for this project/org. unit. The dataset "
+"will inherit the sharing settings of the linked project."
+msgstr ""
+
+msgid ""
+"Sharing settings is not available and the linked project has no user groups "
+"in its sharing settings. The dataset will be saved without sharing settings."
 msgstr ""
 
 msgid "DataSet name"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-12-11T09:29:10.813Z\n"
+"POT-Creation-Date: 2026-07-09T20:12:45.540Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -413,6 +413,16 @@ msgstr "Ninguno"
 
 msgid "Select Project"
 msgstr "Seleccionar proyecto"
+
+msgid ""
+"Sharing settings is not available for this project/org. unit. The dataset "
+"will inherit the sharing settings of the linked project."
+msgstr ""
+
+msgid ""
+"Sharing settings is not available and the linked project has no user groups "
+"in its sharing settings. The dataset will be saved without sharing settings."
+msgstr ""
 
 msgid "DataSet name"
 msgstr "Nombre de dataset"

--- a/src/data/__tests__/D2ApiSharing.spec.ts
+++ b/src/data/__tests__/D2ApiSharing.spec.ts
@@ -1,44 +1,24 @@
 import { D2ApiSharing } from "$/data/D2ApiSharing";
-import { AccessData } from "$/domain/entities/DataSet";
-import { Permission, Permissions } from "$/domain/entities/Permission";
-
-const sharingPermissions: Permissions = {
-    data: Permission.create({ read: true, write: true }),
-    metadata: Permission.create({ read: true, write: false }),
-};
-
-const fallbackAccess: AccessData[] = [
-    {
-        id: "swAdminGroupId",
-        name: "SW_Administrators",
-        type: "groups",
-        permissions: sharingPermissions,
-    },
-    {
-        id: "swUsersGroupId",
-        name: "SW_Users",
-        type: "groups",
-        permissions: sharingPermissions,
-    },
-];
+import { Permission } from "$/domain/entities/Permission";
+import { swAccessGroups } from "$/domain/entities/__tests__/sharingFixtures";
 
 describe("D2ApiSharing", () => {
     it("should generate non-empty userGroups from access copied from the project sharing", () => {
         const d2ApiSharing = new D2ApiSharing();
 
         const result = d2ApiSharing.generateSharingData({
-            access: fallbackAccess,
+            access: swAccessGroups,
             permissions: Permission.noPermissions(),
         });
 
         expect(result.userGroups).toEqual({
-            swAdminGroupId: {
-                id: "swAdminGroupId",
+            OCFhIi9THVW: {
+                id: "OCFhIi9THVW",
                 displayName: "SW_Administrators",
                 access: "r-rw----",
             },
-            swUsersGroupId: {
-                id: "swUsersGroupId",
+            VASLT4IGA6c: {
+                id: "VASLT4IGA6c",
                 displayName: "SW_Users",
                 access: "r-rw----",
             },

--- a/src/data/__tests__/D2ApiSharing.spec.ts
+++ b/src/data/__tests__/D2ApiSharing.spec.ts
@@ -1,0 +1,48 @@
+import { D2ApiSharing } from "$/data/D2ApiSharing";
+import { AccessData } from "$/domain/entities/DataSet";
+import { Permission, Permissions } from "$/domain/entities/Permission";
+
+const sharingPermissions: Permissions = {
+    data: Permission.create({ read: true, write: true }),
+    metadata: Permission.create({ read: true, write: false }),
+};
+
+const fallbackAccess: AccessData[] = [
+    {
+        id: "swAdminGroupId",
+        name: "SW_Administrators",
+        type: "groups",
+        permissions: sharingPermissions,
+    },
+    {
+        id: "swUsersGroupId",
+        name: "SW_Users",
+        type: "groups",
+        permissions: sharingPermissions,
+    },
+];
+
+describe("D2ApiSharing", () => {
+    it("should generate non-empty userGroups from access copied from the project sharing", () => {
+        const d2ApiSharing = new D2ApiSharing();
+
+        const result = d2ApiSharing.generateSharingData({
+            access: fallbackAccess,
+            permissions: Permission.noPermissions(),
+        });
+
+        expect(result.userGroups).toEqual({
+            swAdminGroupId: {
+                id: "swAdminGroupId",
+                displayName: "SW_Administrators",
+                access: "r-rw----",
+            },
+            swUsersGroupId: {
+                id: "swUsersGroupId",
+                displayName: "SW_Users",
+                access: "r-rw----",
+            },
+        });
+        expect(result.users).toEqual({});
+    });
+});

--- a/src/domain/entities/DataSet.ts
+++ b/src/domain/entities/DataSet.ts
@@ -48,6 +48,7 @@ export type DataSetAttrs = {
 export type OrgUnit = { id: Id; code: string; name: string; path: Id[] };
 export type AccessData = { id: Id; permissions: Permissions; name: string; type: AccessType };
 export type AccessType = "users" | "groups";
+export type AccessOrigin = "derived" | "projectFallback" | "none";
 
 export type CoreCompetency = { id: Id; name: string; code: string };
 export type DisabledField = {
@@ -112,11 +113,17 @@ export class DataSet extends Struct<DataSetAttrs>() {
     }
 
     updateAccessFromRegionsCodes(codes: string[], config: Config): DataSet {
-        const access = codes.flatMap(code => {
+        const regionCodes = config.regions.map(region => region.code);
+        const nonRegionAccess = this.access.filter(access => {
+            if (access.type !== "groups") return false;
+            const code = Project.extractCode(access.name);
+            return !code || !regionCodes.includes(code);
+        });
+        const accessFromCodes = codes.flatMap(code => {
             const userGroups = config.userGroups.filter(userGroup => userGroup.code === code);
             return this.buildAccessGroups(userGroups);
         });
-        return this._update({ access: access });
+        return this._update({ access: [...nonRegionAccess, ...accessFromCodes] });
     }
 
     update<K extends keyof DataSet>(fieldName: K, value: DataSet[K]): DataSet {
@@ -317,7 +324,20 @@ export class DataSet extends Struct<DataSetAttrs>() {
         return this.buildAccessGroups(userGroups);
     }
 
+    getAccessOrigin(config: Config): AccessOrigin {
+        const derivedAccess = this.deriveAccessFromProject(this.project, config);
+        if (derivedAccess.length > 0) return "derived";
+        return this.getProjectGroupAccess(this.project).length > 0 ? "projectFallback" : "none";
+    }
+
     private getAccessFromProject(project: Maybe<Project>, config: Config): AccessData[] {
+        if (!project) return [];
+
+        const derivedAccess = this.deriveAccessFromProject(project, config);
+        return derivedAccess.length > 0 ? derivedAccess : this.getProjectGroupAccess(project);
+    }
+
+    private deriveAccessFromProject(project: Maybe<Project>, config: Config): AccessData[] {
         if (!project || !project.code) return [];
 
         const regionCodes = config.regions
@@ -329,6 +349,11 @@ export class DataSet extends Struct<DataSetAttrs>() {
         );
 
         return this.buildAccessGroups(userGroups);
+    }
+
+    private getProjectGroupAccess(project: Maybe<Project>): AccessData[] {
+        if (!project) return [];
+        return project.access.filter(access => access.type === "groups");
     }
 
     private buildAccessGroups(userGroups: UserGroup[]): AccessData[] {

--- a/src/domain/entities/__tests__/DataSet.spec.ts
+++ b/src/domain/entities/__tests__/DataSet.spec.ts
@@ -1,5 +1,5 @@
-import { DataSet, DataSetAttrs } from "$/domain/entities/DataSet";
-import { Permission } from "$/domain/entities/Permission";
+import { AccessData, DataSet, DataSetAttrs } from "$/domain/entities/DataSet";
+import { Permission, Permissions } from "$/domain/entities/Permission";
 import { Project } from "$/domain/entities/Project";
 import { getErrorMessageFromErrors } from "$/domain/entities/generic/Error";
 import { configTest } from "$/utils/tests";
@@ -30,6 +30,37 @@ const projectTest: Project = Project.create({
         },
     ],
 });
+
+const swSharingPermissions: Permissions = {
+    data: Permission.create({ read: true, write: true }),
+    metadata: Permission.create({ read: true, write: false }),
+};
+
+const swAccessGroups: AccessData[] = [
+    {
+        id: "OCFhIi9THVW",
+        name: "SW_Administrators",
+        type: "groups",
+        permissions: swSharingPermissions,
+    },
+    {
+        id: "VASLT4IGA6c",
+        name: "SW_Users",
+        type: "groups",
+        permissions: swSharingPermissions,
+    },
+];
+
+const swUserAccess: AccessData = {
+    id: "swUserId",
+    name: "John Doe",
+    type: "users",
+    permissions: swSharingPermissions,
+};
+
+// SW has no matching region in configTest, so region derivation gives an empty result
+const projectWithoutRegionTest = createProject("SWFM2604", [...swAccessGroups, swUserAccess]);
+const projectWithoutGroupsTest = createProject("GL_CatO:CRFM", [swUserAccess]);
 
 describe("DataSet", () => {
     it("should throw an error if project and org. units are not present", async () => {
@@ -83,10 +114,70 @@ describe("DataSet", () => {
 
         expectUserGroups(dataSetToSave);
     });
+
+    it("should report derived origin when project user groups match a region", async () => {
+        const dataSet = createDataSet({}).updateProject(projectTest, configTest);
+
+        expect(dataSet.getAccessOrigin(configTest)).toBe("derived");
+    });
+
+    it("should fallback to the project user groups when region derivation is empty", async () => {
+        const dataSet = createDataSet({}).updateProject(projectWithoutRegionTest, configTest);
+
+        expect(dataSet.access).toEqual(swAccessGroups);
+        expect(dataSet.getAccessOrigin(configTest)).toBe("projectFallback");
+    });
+
+    it("should not copy project users on fallback, only user groups", async () => {
+        const dataSet = createDataSet({}).updateProject(projectWithoutRegionTest, configTest);
+
+        expect(dataSet.access.every(access => access.type === "groups")).toBe(true);
+    });
+
+    it("should have empty access when project has no user groups in its sharing", async () => {
+        const dataSet = createDataSet({}).updateProject(projectWithoutGroupsTest, configTest);
+
+        expect(dataSet.access).toEqual([]);
+        expect(dataSet.getAccessOrigin(configTest)).toBe("none");
+    });
+
+    it("should keep fallback groups when updating access from region codes", async () => {
+        const dataSet = createDataSet({}).updateProject(projectWithoutRegionTest, configTest);
+
+        const updatedDataSet = dataSet.updateAccessFromRegionsCodes(["AF"], configTest);
+
+        const fallbackGroups = updatedDataSet.access.filter(access =>
+            access.name.startsWith("SW_")
+        );
+        expect(fallbackGroups).toEqual(swAccessGroups);
+        expectUserGroups(updatedDataSet);
+    });
+
+    it("should replace region groups when updating access from region codes", async () => {
+        const dataSet = createDataSet({}).updateProject(projectTest, configTest);
+
+        const updatedDataSet = dataSet.updateAccessFromRegionsCodes([], configTest);
+
+        expect(updatedDataSet.access).toEqual([]);
+    });
 });
 
 function createDataSet(data?: Partial<DataSetAttrs>): DataSet {
     return DataSet.initial(getUid(new Date().getTime().toString()), data);
+}
+
+function createProject(code: string, access: AccessData[]): Project {
+    return Project.create({
+        id: getUid(code),
+        name: `Test Project ${code}`,
+        startDate: new Date().toISOString(),
+        endDate: new Date().toISOString(),
+        code,
+        lastUpdated: new Date().toISOString(),
+        orgsUnits: [],
+        dataSets: [],
+        access,
+    });
 }
 
 function expectUserGroups(dataSet: Maybe<DataSet>) {

--- a/src/domain/entities/__tests__/DataSet.spec.ts
+++ b/src/domain/entities/__tests__/DataSet.spec.ts
@@ -1,7 +1,12 @@
-import { AccessData, DataSet, DataSetAttrs } from "$/domain/entities/DataSet";
-import { Permission, Permissions } from "$/domain/entities/Permission";
+import { DataSet, DataSetAttrs } from "$/domain/entities/DataSet";
+import { Permission } from "$/domain/entities/Permission";
 import { Project } from "$/domain/entities/Project";
 import { getErrorMessageFromErrors } from "$/domain/entities/generic/Error";
+import {
+    projectWithoutGroupsTest,
+    projectWithoutRegionTest,
+    swAccessGroups,
+} from "$/domain/entities/__tests__/sharingFixtures";
 import { configTest } from "$/utils/tests";
 import { Maybe } from "$/utils/ts-utils";
 import { getUid } from "$/utils/uid";
@@ -30,37 +35,6 @@ const projectTest: Project = Project.create({
         },
     ],
 });
-
-const swSharingPermissions: Permissions = {
-    data: Permission.create({ read: true, write: true }),
-    metadata: Permission.create({ read: true, write: false }),
-};
-
-const swAccessGroups: AccessData[] = [
-    {
-        id: "OCFhIi9THVW",
-        name: "SW_Administrators",
-        type: "groups",
-        permissions: swSharingPermissions,
-    },
-    {
-        id: "VASLT4IGA6c",
-        name: "SW_Users",
-        type: "groups",
-        permissions: swSharingPermissions,
-    },
-];
-
-const swUserAccess: AccessData = {
-    id: "swUserId",
-    name: "John Doe",
-    type: "users",
-    permissions: swSharingPermissions,
-};
-
-// SW has no matching region in configTest, so region derivation gives an empty result
-const projectWithoutRegionTest = createProject("SWFM2604", [...swAccessGroups, swUserAccess]);
-const projectWithoutGroupsTest = createProject("GL_CatO:CRFM", [swUserAccess]);
 
 describe("DataSet", () => {
     it("should throw an error if project and org. units are not present", async () => {
@@ -164,20 +138,6 @@ describe("DataSet", () => {
 
 function createDataSet(data?: Partial<DataSetAttrs>): DataSet {
     return DataSet.initial(getUid(new Date().getTime().toString()), data);
-}
-
-function createProject(code: string, access: AccessData[]): Project {
-    return Project.create({
-        id: getUid(code),
-        name: `Test Project ${code}`,
-        startDate: new Date().toISOString(),
-        endDate: new Date().toISOString(),
-        code,
-        lastUpdated: new Date().toISOString(),
-        orgsUnits: [],
-        dataSets: [],
-        access,
-    });
 }
 
 function expectUserGroups(dataSet: Maybe<DataSet>) {

--- a/src/domain/entities/__tests__/sharingFixtures.ts
+++ b/src/domain/entities/__tests__/sharingFixtures.ts
@@ -1,0 +1,52 @@
+import { AccessData } from "$/domain/entities/DataSet";
+import { Permission, Permissions } from "$/domain/entities/Permission";
+import { Project } from "$/domain/entities/Project";
+import { getUid } from "$/utils/uid";
+
+export const swSharingPermissions: Permissions = {
+    data: Permission.create({ read: true, write: true }),
+    metadata: Permission.create({ read: true, write: false }),
+};
+
+export const swAccessGroups: AccessData[] = [
+    {
+        id: "OCFhIi9THVW",
+        name: "SW_Administrators",
+        type: "groups",
+        permissions: swSharingPermissions,
+    },
+    {
+        id: "VASLT4IGA6c",
+        name: "SW_Users",
+        type: "groups",
+        permissions: swSharingPermissions,
+    },
+];
+
+export const swUserAccess: AccessData = {
+    id: "swUserId",
+    name: "John Doe",
+    type: "users",
+    permissions: swSharingPermissions,
+};
+
+// SW has no matching region in configTest, so region derivation gives an empty result
+export const projectWithoutRegionTest = createProject("SWFM2604", [
+    ...swAccessGroups,
+    swUserAccess,
+]);
+export const projectWithoutGroupsTest = createProject("GL_CatO:CRFM", [swUserAccess]);
+
+export function createProject(code: string, access: AccessData[]): Project {
+    return Project.create({
+        id: getUid(code),
+        name: `Test Project ${code}`,
+        startDate: new Date().toISOString(),
+        endDate: new Date().toISOString(),
+        code,
+        lastUpdated: new Date().toISOString(),
+        orgsUnits: [],
+        dataSets: [],
+        access,
+    });
+}

--- a/src/webapp/components/dataset-wizard/SetupDataSet.tsx
+++ b/src/webapp/components/dataset-wizard/SetupDataSet.tsx
@@ -87,6 +87,8 @@ const SetupDataSet_ = React.memo((props: SetupDataSetProps) => {
         [config, onChange, setProjectModalOpen, dataSet]
     );
 
+    const accessOrigin = dataSet.project ? dataSet.getAccessOrigin(config) : undefined;
+
     return (
         <Grid container spacing={2}>
             <Grid item xs={12}>
@@ -104,6 +106,20 @@ const SetupDataSet_ = React.memo((props: SetupDataSetProps) => {
                     }}
                     value={dataSet.project?.name ?? ""}
                 />
+                {accessOrigin === "projectFallback" && (
+                    <Typography variant="body2" color="textSecondary">
+                        {i18n.t(
+                            "Sharing settings is not available for this project/org. unit. The dataset will inherit the sharing settings of the linked project."
+                        )}
+                    </Typography>
+                )}
+                {accessOrigin === "none" && (
+                    <Typography variant="body2" color="error">
+                        {i18n.t(
+                            "Sharing settings is not available and the linked project has no user groups in its sharing settings. The dataset will be saved without sharing settings."
+                        )}
+                    </Typography>
+                )}
             </Grid>
 
             <Grid item xs={12}>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/4528615/869dntzyy #869dntzyy

### :memo: Implementation

If a project is not related to any Country (org. unit level 3) dataSet will be created with no sharing settings. In this PR we're introducing a fallback for this case and set the project (categoryOption) sharing settings to the dataSet.

### :video_camera: Screenshots/Screen capture

**Project without Country related**

https://github.com/user-attachments/assets/5e10d96b-25ee-4822-8b23-321477a31150

**Project with Country related (current funcionality with no changes)** 

https://github.com/user-attachments/assets/53b71249-fea6-4369-8ae4-604e8e50850c

### :fire: Notes to the tester

Explanation with further details on the bug and examples to test -> https://app.clickup.com/t/4528615/869dntzyy?comment=90120227935873