### PR TITLE
Exclude .DS_Store from the release zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "prebuild": "yarn localize && yarn test",
         "manifest": "d2-manifest package.json build/manifest.webapp",
         "build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp && tsc && vite build --outDir=build && yarn run manifest && cp -r i18n icon.png build",
-        "build": "VITE_DHIS2_BASE_URL='' VITE_DHIS2_AUTH='' yarn build-folder && rm -f $npm_package_name.zip && cd build && zip --quiet -r ../$npm_package_name.zip *",
+        "build": "VITE_DHIS2_BASE_URL='' VITE_DHIS2_AUTH='' yarn build-folder && rm -f $npm_package_name.zip && cd build && zip --quiet -r ../$npm_package_name.zip * -x '*.DS_Store'",
         "prettify": "prettier \"./**/*.{js,jsx,json,css,ts,tsx}\" --write",
         "extract-pot": "yarn d2-i18n-extract -p src/ -o i18n/",
         "localize": "yarn update-po && d2-i18n-generate -n d2-dataset-configuration -p ./i18n/ -o ./src/locales/",


### PR DESCRIPTION
`yarn build` copies `public/` into `build/` as-is, so any macOS `.DS_Store` sitting in there ends up inside the packaged webapp. The v3.0.0 zip shipped with `includes/.DS_Store` in it.

`.gitignore` does not help here: the files are never committed, they are picked up from the working copy at build time.

This adds `-x '*.DS_Store'` to the zip step so they cannot reach the artifact regardless of what Finder leaves lying around.

Verified by rebuilding: the new zip has no `.DS_Store` entries and is otherwise identical in content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWRUM23J9f52yDkj8WYKQz