### PR TITLE
fix(entry-form): make custom forms work on DHIS2 v42

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Add core competency to dataSets
  yarn run add-core-competency -u 'http://localhost:8080' --username 'username' --password 'password' --data-set-ids="id1,id2,id3" --core-competency-code="MPC"
 ```
 
+Resave dataSets so their custom forms are regenerated from the current template (a template change only reaches a dataSet when it is saved again)
+
+```bash
+ yarn run resave-datasets -u 'http://localhost:8080' --username 'username' --password 'password' --data-set-ids="id1,id2,id3"
+```
+
+Use `--all` instead of `--data-set-ids` to resave every dataSet in the instance; it must be passed explicitly, an empty `--data-set-ids` is rejected. Prefer explicit ids: saving also rewrites sections and category metadata, not only the entry form.
+
+This script runs through `vite-node`, not `tsx`, because the form templates are imported with Vite's `?raw` suffix.
+
 ### Misc Notes
 
 -   Requests to DHIS2 will be transparently proxied (see `vite.config.ts` -> `server.proxy`) from `http://localhost:8081/dhis2/xyz` to `${VITE_DHIS2_BASE_URL}/xyz`. This prevents CORS and cross-domain problems.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@dhis2/d2-i18n-extract": "1.0.8",
         "@dhis2/d2-i18n-generate": "1.2.0",
         "@dhis2/ui": "6.12.0",
-        "@eyeseetea/d2-api": "1.21.0-beta.2",
+        "@eyeseetea/d2-api": "1.21.0-beta.3",
         "@eyeseetea/d2-ui-components": "2.13.0-beta.5",
         "@material-ui/core": "4.12.4",
         "@material-ui/icons": "4.11.3",
@@ -83,6 +83,7 @@
         "typescript": "5.2.2",
         "vite": "^4.2.0",
         "vite-bundle-visualizer": "^0.6.0",
+        "vite-node": "0.32.4",
         "vite-plugin-checker": "^0.6.2",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-node-stdlib-browser": "^0.2.1",
@@ -116,7 +117,8 @@
         "migrate-period-dates": "tsx src/scripts/migrate-dataset-period-dates",
         "migrate-ds-project": "tsx src/scripts/migrate-dataset-project.ts",
         "add-core-competency": "tsx src/scripts/add-core-compentency-to-datasets.ts",
-        "remove-old-projects": "tsx src/scripts/move-old-projects.ts"
+        "remove-old-projects": "tsx src/scripts/move-old-projects.ts",
+        "resave-datasets": "NODE_ENV=production vite-node src/scripts/resave-datasets.ts --"
     },
     "manifest.webapp": {
         "name": "New DC App",

--- a/src/data/entry-form/template.js
+++ b/src/data/entry-form/template.js
@@ -1,4 +1,3 @@
-var _ = window._;
 var $ = window.$;
 var periodDates = {};
 var indicatorMatching = [];
@@ -13,42 +12,36 @@ function setIndicatorMatching(indicatorMatching_) {
 }
 
 (function () {
-    _.mixin({
-        cartesianProduct: function (args) {
-            return _.reduce(
-                args,
-                function (a, b) {
-                    return _.flatten(
-                        _.map(a, function (x) {
-                            return _.map(b, function (y) {
-                                return x.concat([y]);
-                            });
-                        }),
-                        true
-                    );
-                },
-                [[]]
-            );
-        },
+    // Reason: the v42 data entry app no longer exposes lodash to custom forms
+    const last = xs => xs[xs.length - 1];
 
-        groupConsecutiveBy: function (xs, mapper) {
-            mapper = mapper || _.identity;
-            var reducer = (acc, x) => {
-                if (_.isEmpty(acc)) {
-                    return acc.concat([[x]]);
-                } else {
-                    var last = _.last(acc);
-                    if (_.isEqual(mapper(_.last(last)), mapper(x))) {
-                        last.push(x);
-                        return acc;
-                    } else {
-                        return acc.concat([[x]]);
-                    }
-                }
-            };
-            return _(xs).reduce(reducer, []);
-        },
-    });
+    const range = n => Array.from(Array(n), (_value, index) => index);
+
+    const uniq = xs => Array.from(new Set(xs));
+
+    const max = xs => (xs.length === 0 ? undefined : xs.reduce((a, b) => Math.max(a, b)));
+
+    const zip = arrays =>
+        range(max(arrays.map(array => array.length)) ?? 0).map(index =>
+            arrays.map(array => array[index])
+        );
+
+    const isEqual = (a, b) =>
+        Array.isArray(a) && Array.isArray(b)
+            ? a.length === b.length && a.every((x, index) => isEqual(x, b[index]))
+            : a === b;
+
+    // Groups adjacent items sharing the same mapped key: [a1, a2, b1] -> [[a1, a2], [b1]]
+    const groupConsecutiveBy = (xs, mapper = x => x) =>
+        xs.reduce((groups, x) => {
+            const lastGroup = last(groups);
+            return lastGroup && isEqual(mapper(last(lastGroup)), mapper(x))
+                ? [...groups.slice(0, -1), [...lastGroup, x]]
+                : [...groups, [x]];
+        }, []);
+
+    const groupCocsByCategory = (cocs, categoryIndex) =>
+        groupConsecutiveBy(cocs, coc => coc.cos.slice(0, categoryIndex + 1));
 
     var debugElapsed = (label, fn) => {
         var start = new Date().getTime();
@@ -90,53 +83,57 @@ function setIndicatorMatching(indicatorMatching_) {
                     .find("thead tr")
                     .get()
                     .map(tr =>
-                        _.chain($(tr).find("th[scope=col]").get())
-                            .map(th => [
-                                repeat(parseInt($(th).attr("colspan")), $(th).text().trim()),
-                            ])
-                            .flatten()
-                            .value()
+                        $(tr)
+                            .find("th[scope=col]")
+                            .get()
+                            .flatMap(th =>
+                                repeat(parseInt($(th).attr("colspan")), $(th).text().trim())
+                            )
                     );
 
-                var categoryOptions = _.zip.apply(null, allCategoryOptions);
+                var categoryOptions = zip(allCategoryOptions);
                 var uniqCategories = allCategoryOptions.map(categoryOptions =>
-                    _.uniq(categoryOptions)
+                    uniq(categoryOptions)
                 );
                 if (categoryOptions.length !== cocIds.length) {
                     alert("Error: parsing of form failed");
                 }
-                var cocs = _.zip(categoryOptions, cocIds).map(pair => ({
+                var cocs = zip([categoryOptions, cocIds]).map(pair => ({
                     cos: pair[0],
                     id: pair[1],
                 }));
 
-                var rows = _.chain(table.find("tbody tr").get())
+                var rows = table
+                    .find("tbody tr")
+                    .get()
                     .map($)
-                    .map(tr => {
-                        var td = tr.find("td:first-child");
-                        var tdId = td.attr("id");
+                    .flatMap(tr => {
+                        const td = tr.find("td:first-child");
+                        const tdId = td.attr("id");
+                        if (!tdId) return [];
 
-                        if (tdId) {
-                            var deId = tdId.split("-")[0];
-                            var deName = td.text().trim();
-                            var valuesByCocId = _.chain(tr.find("td .entryfield").get())
+                        const valuesByCocId = Object.fromEntries(
+                            tr
+                                .find("td .entryfield")
+                                .get()
                                 .map($)
                                 .map(input => {
-                                    var cocId = input.attr("id").split("-")[1];
+                                    const cocId = input.attr("id").split("-")[1];
                                     return [cocId, { td: input.parent("td"), coc: cocId }];
                                 })
-                                .object()
-                                .value();
-                            return {
-                                de: { id: deId, name: deName, td: td },
+                        );
+
+                        return [
+                            {
+                                de: {
+                                    id: tdId.split("-")[0],
+                                    name: td.text().trim(),
+                                    td: td,
+                                },
                                 valuesByCocId: valuesByCocId,
-                            };
-                        } else {
-                            return null;
-                        }
-                    })
-                    .compact()
-                    .value();
+                            },
+                        ];
+                    });
 
                 var data = {
                     group: table.find("nrcinfoheader").text().trim(),
@@ -172,35 +169,32 @@ function setIndicatorMatching(indicatorMatching_) {
         if (categoryIndex >= nCategories - 1 || tableFitsInViewport(table)) {
             return [table];
         } else {
-            return _.chain(data.cocs)
-                .groupConsecutiveBy(coc => coc.cos.slice(0, categoryIndex + 1))
-                .map((splitCocs, splitTableIndex) =>
-                    splitTables(_.extend({}, data, { cocs: splitCocs }), {
-                        categoryIndex: categoryIndex + 1,
-                        tableIndex: options.tableIndex + splitTableIndex,
-                    })
-                )
-                .flatten(1)
-                .value();
+            return groupCocsByCategory(data.cocs, categoryIndex).flatMap(
+                (splitCocs, splitTableIndex) =>
+                    splitTables(
+                        { ...data, cocs: splitCocs },
+                        {
+                            categoryIndex: categoryIndex + 1,
+                            tableIndex: options.tableIndex + splitTableIndex,
+                        }
+                    )
+            );
         }
     };
 
     var buildTable = function (data, renderDataElementInfo) {
         var getValues = row => data.cocs.map(coc => row.valuesByCocId[coc.id]);
         var nCategories = data.categories.length;
-        var categoryThsList = _.range(nCategories).map(categoryIndex => {
-            return _.chain(data.cocs)
-                .groupConsecutiveBy(coc => coc.cos.slice(0, categoryIndex + 1))
-                .map(group => {
-                    var label = group[0].cos[categoryIndex];
-                    return $("<th>", {
-                        class: "nrcdataheader",
-                        colspan: group.length,
-                        scope: "col",
-                    }).text(label);
-                })
-                .value();
-        });
+        var categoryThsList = range(nCategories).map(categoryIndex =>
+            groupCocsByCategory(data.cocs, categoryIndex).map(group => {
+                var label = group[0].cos[categoryIndex];
+                return $("<th>", {
+                    class: "nrcdataheader",
+                    colspan: group.length,
+                    scope: "col",
+                }).text(label);
+            })
+        );
 
         return $("<table>", { id: "sectionTable", class: "sectionTable", cellspacing: "0" }).append(
             [
@@ -281,11 +275,14 @@ function setIndicatorMatching(indicatorMatching_) {
     };
 
     var renumerateInputFields = function () {
+        // Reason: a non-numeric tabindex would otherwise poison max to NaN, collapsing lastIndex to 0
         var lastIndex =
-            _.chain($("[tabindex]").get())
-                .map(x => parseInt($(x).attr("tabindex")))
-                .max()
-                .value() || 0;
+            max(
+                $("[tabindex]")
+                    .get()
+                    .map(x => parseInt($(x).attr("tabindex")))
+                    .filter(tabIndex => !Number.isNaN(tabIndex))
+            ) || 0;
         $("#contentDiv .entryfield").each((i, input) =>
             $(input).attr("tabindex", lastIndex + i + 1)
         );
@@ -491,6 +488,8 @@ function setIndicatorMatching(indicatorMatching_) {
         $("#selectedPeriodId").change(applyPeriodDates);
         loadJs("../dhis-web-commons/bootstrap/js/bootstrap.min.js");
         loadCss("../dhis-web-commons/bootstrap/css/bootstrap.min.css");
+        // Reason: the v42 data entry app no longer loads FontAwesome, used for the accordion arrows
+        loadCss("../dhis-web-commons/font-awesome/css/font-awesome.min.css");
     };
 
     $(init);

--- a/src/data/entry-form/template.js
+++ b/src/data/entry-form/template.js
@@ -328,17 +328,31 @@ function setIndicatorMatching(indicatorMatching_) {
         }
     };
 
-    var applyPeriodDates = function () {
+    var formatDate = function (date) {
+        const d = new Date(date);
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, "0");
+        const day = String(d.getDate()).padStart(2, "0");
+        return [day, month, year].join("/");
+    };
+
+    // Reason: v42 never populates dhis2.de.periodChoices, so getSelectedPeriod() always returns
+    // undefined. currentPeriodId and #selectedPeriodId are both supported by its legacy shim.
+    var getSelectedPeriodYear = function () {
         /* eslint-disable no-undef */
-        const selectedPeriod = dhis2.de.getSelectedPeriod();
-        if (!selectedPeriod || !selectedPeriod.startDate) return;
+        const periodId =
+            (window.dhis2 && dhis2.de && dhis2.de.currentPeriodId) || $("#selectedPeriodId").val();
+        return periodId ? String(periodId).slice(0, 4) : undefined;
+    };
+
+    var applyPeriodDates = function () {
+        const periodYear = getSelectedPeriodYear();
+        if (!periodYear) return;
         const getDate = isoDate => (isoDate ? new Date(isoDate.split("T")[0]) : null);
         const getFormatDate = isoDate =>
-            isoDate ? formatDate(new Date(isoDate.split("T")[0]), "dd/MM/yyyy") : null;
-        const startDate = selectedPeriod.startDate;
-        const periodYear = startDate.split("-")[0];
+            isoDate ? formatDate(new Date(isoDate.split("T")[0])) : null;
         const today = new Date();
-        console.debug("applyPeriodDates", { periodDates, selectedPeriod, periodYear, today });
+        console.debug("applyPeriodDates", { periodDates, periodYear, today });
 
         ["output", "outcome"].forEach(type => {
             const obj = (periodDates[type] || {})[periodYear];

--- a/src/data/repositories/DataElementD2Repository.ts
+++ b/src/data/repositories/DataElementD2Repository.ts
@@ -4,6 +4,7 @@ import { COMMENT_SUFIX, DataElement } from "$/domain/entities/DataElement";
 import { Future, FutureData } from "$/domain/entities/generic/Future";
 import { DataElementRepository } from "$/domain/repositories/DataElementRepository";
 import { D2Api } from "$/types/d2-api";
+import { isValidUid } from "$/utils/uid";
 
 export class DataElementD2Repository implements DataElementRepository {
     constructor(private api: D2Api) {}
@@ -68,7 +69,11 @@ export class DataElementD2Repository implements DataElementRepository {
                         categoryOptionCombos: { id: true, displayName: true },
                     },
                 },
-                filter: { identifiable: { in: identifiables } },
+                filter: {
+                    id: { in: identifiables.filter(isValidUid) },
+                    code: { in: identifiables.filter(value => !isValidUid(value)) },
+                },
+                rootJunction: "OR",
                 paging: false,
             })
         ).map(response => {

--- a/src/scripts/resave-datasets.ts
+++ b/src/scripts/resave-datasets.ts
@@ -1,0 +1,97 @@
+import { command, run, string, option, optional, flag } from "cmd-ts";
+import path from "path";
+import { D2Api } from "$/types/d2-api";
+import { ConfigD2Repository } from "$/data/repositories/ConfigD2Repository";
+import { DataSetD2Repository } from "$/data/repositories/DataSetD2Repository";
+
+function main() {
+    const cmd = command({
+        name: path.basename(__filename),
+        description: "Resave data sets so their custom forms are regenerated",
+        args: {
+            url: option({
+                type: string,
+                long: "dhis2-url",
+                short: "u",
+                description: "DHIS2 base URL. Example: http://localhost:8080",
+            }),
+            username: option({
+                type: string,
+                long: "username",
+                short: "s",
+            }),
+            password: option({
+                type: string,
+                long: "password",
+                short: "p",
+            }),
+            dataSetIds: option({
+                type: optional(string),
+                long: "data-set-ids",
+                short: "d",
+                description: "Comma separated list of dataSets ids",
+            }),
+            all: flag({
+                long: "all",
+                description:
+                    "Resave every data set in the instance. Required when --data-set-ids is not given",
+            }),
+        },
+        handler: async args => {
+            const auth = { username: args.username, password: args.password };
+            const api = new D2Api({ baseUrl: args.url, auth: auth });
+            const dataSetIds = parseDataSetIds(args.dataSetIds);
+            const hasDataSetIds = dataSetIds.length > 0;
+
+            // Reason: resaving every data set must be asked for, never the result of an empty argument
+            if (args.all && args.dataSetIds !== undefined) {
+                console.error("Pass either --all or --data-set-ids, not both");
+                process.exit(1);
+            } else if (!args.all && !hasDataSetIds) {
+                console.error(
+                    args.dataSetIds === undefined
+                        ? "Pass --data-set-ids <ids>, or --all to resave every data set"
+                        : "--data-set-ids contained no valid ids"
+                );
+                process.exit(1);
+            }
+
+            console.debug("Loading configuration...");
+            const configRepository = new ConfigD2Repository(api);
+            const config = await configRepository.get().toPromise();
+            const dataSetRepository = new DataSetD2Repository(api, config);
+
+            console.debug(
+                hasDataSetIds
+                    ? `Fetching ${dataSetIds.length} data set/s...`
+                    : "Fetching all data sets..."
+            );
+            const dataSets = hasDataSetIds
+                ? await dataSetRepository.getByIds(dataSetIds).toPromise()
+                : await dataSetRepository.getAll().toPromise();
+
+            if (dataSets.length === 0) {
+                console.debug("No data sets to resave");
+                return;
+            }
+
+            console.debug(`Resaving ${dataSets.length} data set/s...`);
+            await dataSetRepository.save(dataSets).toPromise();
+            console.debug("Done");
+        },
+    });
+
+    run(cmd, process.argv.slice(2)).catch(error => {
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+function parseDataSetIds(dataSetIds: string | undefined): string[] {
+    return (dataSetIds ?? "")
+        .split(",")
+        .map(id => id.trim())
+        .filter(id => id !== "");
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,10 +2755,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.49.0.tgz#86f79756004a97fa4df866835093f1df3d03c333"
   integrity sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==
 
-"@eyeseetea/d2-api@1.21.0-beta.2":
-  version "1.21.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.21.0-beta.2.tgz#2b6c86534932e3c552e5580ecf37b114cc552d6c"
-  integrity sha512-5ZEtU6u0isx3HEKRGSqxbw0obKoKtuRnTPdnmLmdvJA8A93HOCUQcJ9DYYUkDtmBqsc6a2tzCBlzHZ32Sd2x6w==
+"@eyeseetea/d2-api@1.21.0-beta.3":
+  version "1.21.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.21.0-beta.3.tgz#ec66d12f2e76492d81fbab2bf40a4406499de87e"
+  integrity sha512-eKG+eL/0pDPjmLfdSQiSXKBMq5WazWCM64Ck8tlF8hRtShIeS4euyMh0WHUJlsEk9n4m6pcG51DvCX0vmX5GMw==
   dependencies:
     abort-controller "3.0.0"
     axios "1.6.4"


### PR DESCRIPTION
### :pushpin: References

-   **Task:** #869arp855 [See how we can use forms in v42](https://app.clickup.com/t/869arp855)

### :memo: Implementation

**Issue**: on DHIS2 v42 our custom forms render, but their JavaScript doesn't run. The v42 data entry app detects a `<script>` in the stored form and falls back to a legacy renderer that loads jQuery and bootstrap, but not lodash. All default behavior works out of the box but what is silently lost are: wide table splitting, period date visibility, indicator matching, row highlighting and tab index renumbering.

-   `template.js` no longer depends on lodash. The removed `_.mixin` helpers and the ~20 call sites are replaced by local helpers (`last`, `range`, `uniq`, `max`, `zip`, `isEqual`, `groupConsecutiveBy`) plus native array methods.
-   `renumerateInputFields` filters non numeric tabindex values before taking the max, matching lodash 3 which skipped `NaN`. On an empty selection it now returns 0 rather than `-Infinity`, fixing a latent `tabindex="-Infinity"`.
-   Load `font-awesome`, which v42 no longer provides, so the accordion arrows render again.
-   New `resave-datasets` script, since a template change only reaches a dataset when it is saved again.
-   Bump `@eyeseetea/d2-api` to `1.21.0-beta.3`. beta.2 dereferences `options.agent` outside the browser, so any node script using `D2Api` throws before its first request. The two versions differ by one line.
- remove data element query `identifiable:in:[...]`

### :video_camera: Screenshots/Screen capture

**Column Split**
<img width="1536" height="819" alt="image" src="https://github.com/user-attachments/assets/1f649d30-9944-4f7d-8e87-7d011e3baf68" />


**Indicator Mataching**

https://github.com/user-attachments/assets/e0850820-f33f-4d4b-99d2-ad1a04d81426



### :fire: Notes to the tester
Tested on the v42 image at `172.16.2.100:8280` with the limited user. Two datasets are set up there for comparison, same project, org unit and indicators, differing only in which template generated the form:

-   Broken form (`G4gblKVb2mW`, "ZZ TEST v42 custom form BROKEN") [data entry](http://172.16.2.100:8280/dhis-web-aggregate-data-entry/index.html#/?dataSetId=G4gblKVb2mW&orgUnitId=jBhgPKfZUHH&periodId=202607&attributeOptionComboSelection=MRwzyV0kXv9-BqHyaA3eVjh_ouNRBWIbnxY-DV4a5V9Psk4_sHta2dMEOLO-G6MUpZs8CZP)
-   Fixed form (`Ko0O53NLW2l`, "ZZ TEST v42 custom form") [data entry](http://172.16.2.100:8280/dhis-web-aggregate-data-entry/index.html#/?dataSetId=G4gblKVb2mW&orgUnitId=jBhgPKfZUHH&periodId=202607&attributeOptionComboSelection=MRwzyV0kXv9-BqHyaA3eVjh_ouNRBWIbnxY-DV4a5V9Psk4_sHta2dMEOLO-G6MUpZs8CZP)
- Broken indicator matching (muMd03zWvZx, "JOFM2119 DataSet - test broken im") [data entry](http://172.16.2.100:8280/apps/aggregate-data-entry#/?attributeOptionComboSelection=MRwzyV0kXv9-e9hUNSHw9Cs_ouNRBWIbnxY-L3wRUWPGgC1_sHta2dMEOLO-G6MUpZs8CZP&dataSetId=muMd03zWvZx&orgUnitId=tiqiZ84NcY6&periodId=202612&sectionFilter=KMM3c4x2I7Z) 
- Fixed indicator matching + disable Disable2026bvFA7fsiN3T (OOkBnKfPvh7, "JOFM2602 DataSet") [data entry](http://172.16.2.100:8280/apps/aggregate-data-entry#/?attributeOptionComboSelection=MRwzyV0kXv9-qQEV3TNwvl8_ouNRBWIbnxY-DV4a5V9Psk4_sHta2dMEOLO-G6MUpZs8CZP&dataSetId=OOkBnKfPvh7&orgUnitId=WEZOcgKDs7j&periodId=202612&sectionFilter=CS2XpCKfrrz)

What to look for:
-   Broken: one table 98 columns wide running off the page, and `TypeError: Cannot read properties of undefined (reading 'mixin')` in the console.
-   Fixed: the same table split into 7 tables, none wider than 14 columns, console logs `Split tables: 1, tables created: 7`, and the theme headings show their collapse arrows.

```shell
yarn resave-datasets --dhis2-url="http://localhost:8080" --username="admin" --password="district" --data-set-ids="Ko0O53NLW2l"
```

`--all` resaves every dataset in the instance. Note `save` also rewrites sections and category metadata, so prefer explicit ids.

Verified on the v42 image after this change: table splitting, tab index renumbering and row highlighting all work.